### PR TITLE
Check for existing district key

### DIFF
--- a/scripts/make_constituencies2.py
+++ b/scripts/make_constituencies2.py
@@ -26,7 +26,8 @@ with open(constituency_path, 'r') as constituencies_file:
         for region in constituencies_json[county]['regions']:
             constituency_code = county+str(region['constituency'])
             for district in region['district']:
-                village_constituency_map[district] = {}
+                if not district in village_constituency_map[county]:
+                    village_constituency_map[county][district] = {}
                 for village in region['district'][district]:
                     village_constituency_map[district][village]=constituency_code
 


### PR DESCRIPTION
As districts may appear more than once for the county, as
part of different constituencies, we need to check that we
haven't already seen a district otherwise we overwrite the
exiting hash.