### PR TITLE
Wikidata languages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/everypolitician/commons-builder.git
-  revision: d438eee54e43bd59c1660bfd32aa1a16b211e9fb
+  revision: 0e34a060ae8b124e4e1131bb540379ea1f5acccc
   specs:
     commons-builder (0.1.0)
       rest-client (~> 2.0.2)
@@ -8,7 +8,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
-    "language_map": {
-      "lang:zh_TW": "zh-tw",
-      "lang:en_US": "en"
-    },
-    "country_wikidata_id": "Q865"
+  "languages": [
+    "zh-tw",
+    "en"
+  ],
+  "country_wikidata_id": "Q865"
 }

--- a/executive/Q10924139/current/popolo-m17n.json
+++ b/executive/Q10924139/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "張花冠",
-        "lang:en_US": "Helen Chang"
+        "lang:zh-tw": "張花冠",
+        "lang:en": "Helen Chang"
       },
       "id": "Q8347506",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "嘉義縣政府",
-        "lang:en_US": "Chiayi County Government"
+        "lang:zh-tw": "嘉義縣政府",
+        "lang:en": "Chiayi County Government"
       },
       "id": "Q10924139",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -65,8 +65,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -90,8 +90,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -115,8 +115,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -140,8 +140,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -165,8 +165,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -190,8 +190,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -215,8 +215,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -240,8 +240,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -265,8 +265,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -290,8 +290,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -315,8 +315,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -340,8 +340,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -365,8 +365,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -390,8 +390,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -415,8 +415,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -440,8 +440,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -465,8 +465,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -490,8 +490,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -515,8 +515,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -540,8 +540,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -565,8 +565,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -590,8 +590,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -615,8 +615,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -634,13 +634,13 @@
       "start_date": "2009-12-20",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50292905",
       "role": {
-        "lang:zh_TW": "嘉義縣縣長",
-        "lang:en_US": "Mayor of Chiayi County"
+        "lang:zh-tw": "嘉義縣縣長",
+        "lang:en": "Mayor of Chiayi County"
       }
     }
   ]

--- a/executive/Q10930430/current/popolo-m17n.json
+++ b/executive/Q10930430/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "林右昌",
-        "lang:en_US": "Lin Yu-chang"
+        "lang:zh-tw": "林右昌",
+        "lang:en": "Lin Yu-chang"
       },
       "id": "Q8349914",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "基隆市政府",
-        "lang:en_US": "Keelung City Government"
+        "lang:zh-tw": "基隆市政府",
+        "lang:en": "Keelung City Government"
       },
       "id": "Q10930430",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -65,8 +65,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -90,8 +90,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -115,8 +115,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -140,8 +140,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -165,8 +165,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -190,8 +190,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -215,8 +215,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -240,8 +240,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -265,8 +265,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -290,8 +290,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -315,8 +315,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -340,8 +340,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -365,8 +365,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -390,8 +390,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -415,8 +415,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -440,8 +440,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -465,8 +465,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -490,8 +490,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -515,8 +515,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -540,8 +540,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -565,8 +565,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -590,8 +590,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -615,8 +615,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -634,13 +634,13 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q6797738",
       "role": {
-        "lang:zh_TW": "基隆市市長",
-        "lang:en_US": "Mayor of Keelung"
+        "lang:zh-tw": "基隆市市長",
+        "lang:en": "Mayor of Keelung"
       }
     }
   ]

--- a/executive/Q10949116/current/popolo-m17n.json
+++ b/executive/Q10949116/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "陳金德",
-        "lang:en_US": "Chen Chin-te"
+        "lang:zh-tw": "陳金德",
+        "lang:en": "Chen Chin-te"
       },
       "id": "Q8348181",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "宜蘭縣政府",
-        "lang:en_US": "Yilan County Government"
+        "lang:zh-tw": "宜蘭縣政府",
+        "lang:en": "Yilan County Government"
       },
       "id": "Q10949116",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -65,8 +65,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -90,8 +90,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -115,8 +115,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -140,8 +140,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -165,8 +165,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -190,8 +190,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -215,8 +215,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -240,8 +240,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -265,8 +265,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -290,8 +290,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -315,8 +315,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -340,8 +340,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -365,8 +365,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -390,8 +390,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -415,8 +415,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -440,8 +440,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -465,8 +465,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -490,8 +490,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -515,8 +515,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -540,8 +540,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -565,8 +565,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -590,8 +590,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -615,8 +615,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -634,13 +634,13 @@
       "start_date": "2017-11-06",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50306553",
       "role": {
-        "lang:zh_TW": "宜蘭縣縣長",
-        "lang:en_US": "Mayor of Yilan County"
+        "lang:zh-tw": "宜蘭縣縣長",
+        "lang:en": "Mayor of Yilan County"
       }
     }
   ]

--- a/executive/Q11042707/current/popolo-m17n.json
+++ b/executive/Q11042707/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -47,8 +47,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -72,8 +72,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -97,8 +97,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -122,8 +122,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -147,8 +147,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -172,8 +172,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -197,8 +197,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -222,8 +222,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -247,8 +247,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -272,8 +272,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -297,8 +297,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -322,8 +322,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -347,8 +347,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -372,8 +372,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -397,8 +397,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -422,8 +422,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -447,8 +447,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -472,8 +472,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -497,8 +497,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -522,8 +522,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -547,8 +547,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -572,8 +572,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",

--- a/executive/Q11070045/current/popolo-m17n.json
+++ b/executive/Q11070045/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -47,8 +47,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -72,8 +72,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -97,8 +97,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -122,8 +122,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -147,8 +147,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -172,8 +172,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -197,8 +197,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -222,8 +222,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -247,8 +247,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -272,8 +272,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -297,8 +297,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -322,8 +322,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -347,8 +347,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -372,8 +372,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -397,8 +397,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -422,8 +422,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -447,8 +447,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -472,8 +472,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -497,8 +497,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -522,8 +522,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -547,8 +547,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -572,8 +572,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",

--- a/executive/Q11081380/current/popolo-m17n.json
+++ b/executive/Q11081380/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "朱立倫",
-        "lang:en_US": "Eric Chu"
+        "lang:zh-tw": "朱立倫",
+        "lang:en": "Eric Chu"
       },
       "id": "Q5386280",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "新北市政府",
-        "lang:en_US": "New Taipei City Government"
+        "lang:zh-tw": "新北市政府",
+        "lang:en": "New Taipei City Government"
       },
       "id": "Q11081380",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -65,8 +65,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -90,8 +90,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -115,8 +115,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -140,8 +140,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -165,8 +165,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -190,8 +190,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -215,8 +215,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -240,8 +240,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -265,8 +265,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -290,8 +290,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -315,8 +315,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -340,8 +340,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -365,8 +365,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -390,8 +390,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -415,8 +415,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -440,8 +440,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -465,8 +465,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -490,8 +490,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -515,8 +515,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -540,8 +540,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -565,8 +565,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -590,8 +590,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -615,8 +615,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -634,13 +634,13 @@
       "start_date": "2010-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q6797771",
       "role": {
-        "lang:zh_TW": "新北市市長",
-        "lang:en_US": "Mayor of New Taipei"
+        "lang:zh-tw": "新北市市長",
+        "lang:en": "Mayor of New Taipei"
       }
     }
   ]

--- a/executive/Q11083998/current/popolo-m17n.json
+++ b/executive/Q11083998/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "林智堅",
-        "lang:en_US": "Lin Chih-chien"
+        "lang:zh-tw": "林智堅",
+        "lang:en": "Lin Chih-chien"
       },
       "id": "Q8347529",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "新竹市政府",
-        "lang:en_US": "Hsinchu City Government"
+        "lang:zh-tw": "新竹市政府",
+        "lang:en": "Hsinchu City Government"
       },
       "id": "Q11083998",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -65,8 +65,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -90,8 +90,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -115,8 +115,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -140,8 +140,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -165,8 +165,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -190,8 +190,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -215,8 +215,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -240,8 +240,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -265,8 +265,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -290,8 +290,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -315,8 +315,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -340,8 +340,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -365,8 +365,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -390,8 +390,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -415,8 +415,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -440,8 +440,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -465,8 +465,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -490,8 +490,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -515,8 +515,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -540,8 +540,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -565,8 +565,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -590,8 +590,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -615,8 +615,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -634,13 +634,13 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50292741",
       "role": {
-        "lang:zh_TW": "新竹市市長",
-        "lang:en_US": "Mayor of Hsinchu"
+        "lang:zh-tw": "新竹市市長",
+        "lang:en": "Mayor of Hsinchu"
       }
     }
   ]

--- a/executive/Q11084050/current/popolo-m17n.json
+++ b/executive/Q11084050/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "邱鏡淳",
-        "lang:en_US": "Chiu Ching-chun"
+        "lang:zh-tw": "邱鏡淳",
+        "lang:en": "Chiu Ching-chun"
       },
       "id": "Q8273181",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "新竹縣政府",
-        "lang:en_US": "Hsinchu County Government"
+        "lang:zh-tw": "新竹縣政府",
+        "lang:en": "Hsinchu County Government"
       },
       "id": "Q11084050",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -65,8 +65,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -90,8 +90,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -115,8 +115,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -140,8 +140,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -165,8 +165,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -190,8 +190,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -215,8 +215,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -240,8 +240,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -265,8 +265,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -290,8 +290,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -315,8 +315,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -340,8 +340,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -365,8 +365,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -390,8 +390,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -415,8 +415,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -440,8 +440,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -465,8 +465,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -490,8 +490,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -515,8 +515,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -540,8 +540,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -565,8 +565,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -590,8 +590,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -615,8 +615,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -634,13 +634,13 @@
       "start_date": "2009-12-20",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50293600",
       "role": {
-        "lang:zh_TW": "新竹縣縣長",
-        "lang:en_US": "Mayor of Hsinchu County"
+        "lang:zh-tw": "新竹縣縣長",
+        "lang:en": "Mayor of Hsinchu County"
       }
     }
   ]

--- a/executive/Q15897754/current/popolo-m17n.json
+++ b/executive/Q15897754/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "涂醒哲",
-        "lang:en_US": "Twu Shiing-jer"
+        "lang:zh-tw": "涂醒哲",
+        "lang:en": "Twu Shiing-jer"
       },
       "id": "Q8350363",
       "identifiers": [
@@ -18,7 +18,7 @@
     },
     {
       "name": {
-        "lang:en_US": "Chang Wen-ying"
+        "lang:en": "Chang Wen-ying"
       },
       "id": "Q9188552",
       "identifiers": [
@@ -35,8 +35,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "嘉義市政府",
-        "lang:en_US": "Chiayi City Government"
+        "lang:zh-tw": "嘉義市政府",
+        "lang:en": "Chiayi City Government"
       },
       "id": "Q15897754",
       "classification": "branch",
@@ -50,8 +50,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -80,8 +80,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -105,8 +105,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -130,8 +130,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -155,8 +155,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -180,8 +180,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -205,8 +205,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -230,8 +230,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -255,8 +255,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -280,8 +280,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -305,8 +305,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -330,8 +330,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -355,8 +355,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -380,8 +380,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -405,8 +405,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -430,8 +430,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -455,8 +455,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -480,8 +480,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -505,8 +505,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -530,8 +530,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -555,8 +555,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -580,8 +580,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -605,8 +605,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -630,8 +630,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -649,13 +649,13 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q6627476",
       "role": {
-        "lang:zh_TW": "嘉義市市長",
-        "lang:en_US": "Mayor of Chiayi"
+        "lang:zh-tw": "嘉義市市長",
+        "lang:en": "Mayor of Chiayi"
       }
     },
     {
@@ -664,13 +664,13 @@
       "organization_id": "Q15897754",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q6627476",
       "role": {
-        "lang:zh_TW": "嘉義市市長",
-        "lang:en_US": "Mayor of Chiayi"
+        "lang:zh-tw": "嘉義市市長",
+        "lang:en": "Mayor of Chiayi"
       }
     }
   ]

--- a/executive/Q15898718/current/popolo-m17n.json
+++ b/executive/Q15898718/current/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:en_US": "Jason Hu"
+        "lang:en": "Jason Hu"
       },
       "id": "Q284597",
       "identifiers": [
@@ -19,8 +19,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "臺中市政府",
-        "lang:en_US": "Taichung City Government"
+        "lang:zh-tw": "臺中市政府",
+        "lang:en": "Taichung City Government"
       },
       "id": "Q15898718",
       "classification": "branch",
@@ -34,8 +34,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -64,8 +64,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -89,8 +89,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -114,8 +114,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -139,8 +139,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -164,8 +164,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -189,8 +189,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -214,8 +214,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -239,8 +239,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -264,8 +264,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -289,8 +289,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -314,8 +314,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -339,8 +339,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -364,8 +364,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -389,8 +389,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -414,8 +414,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -439,8 +439,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -464,8 +464,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -489,8 +489,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -514,8 +514,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -539,8 +539,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -564,8 +564,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -589,8 +589,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -614,8 +614,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -632,13 +632,13 @@
       "organization_id": "Q15898718",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q6797822",
       "role": {
-        "lang:zh_TW": "臺中市市長",
-        "lang:en_US": "Mayor of Taichung"
+        "lang:zh-tw": "臺中市市長",
+        "lang:en": "Mayor of Taichung"
       }
     }
   ]

--- a/executive/Q15904117/current/popolo-m17n.json
+++ b/executive/Q15904117/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "劉增應",
-        "lang:en_US": "Liu Cheng-ying"
+        "lang:zh-tw": "劉增應",
+        "lang:en": "Liu Cheng-ying"
       },
       "id": "Q18612457",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "連江縣政府",
-        "lang:en_US": "Lienchiang County Government"
+        "lang:zh-tw": "連江縣政府",
+        "lang:en": "Lienchiang County Government"
       },
       "id": "Q15904117",
       "classification": "branch",
@@ -51,8 +51,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -76,8 +76,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -101,8 +101,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -126,8 +126,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -151,8 +151,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -176,8 +176,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -201,8 +201,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -226,8 +226,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -251,8 +251,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -276,8 +276,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -301,8 +301,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -326,8 +326,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -351,8 +351,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -376,8 +376,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -401,8 +401,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -426,8 +426,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -451,8 +451,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -476,8 +476,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -501,8 +501,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -526,8 +526,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -551,8 +551,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -576,8 +576,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -601,8 +601,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -619,13 +619,13 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50293953",
       "role": {
-        "lang:zh_TW": "連江縣縣長",
-        "lang:en_US": "Mayor of Lienchiang"
+        "lang:zh-tw": "連江縣縣長",
+        "lang:en": "Mayor of Lienchiang"
       }
     }
   ]

--- a/executive/Q15909106/current/popolo-m17n.json
+++ b/executive/Q15909106/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "李進勇",
-        "lang:en_US": "Lee Chin-yung"
+        "lang:zh-tw": "李進勇",
+        "lang:en": "Lee Chin-yung"
       },
       "id": "Q8349734",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "雲林縣政府",
-        "lang:en_US": "Yunlin County Government"
+        "lang:zh-tw": "雲林縣政府",
+        "lang:en": "Yunlin County Government"
       },
       "id": "Q15909106",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -65,8 +65,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -90,8 +90,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -115,8 +115,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -140,8 +140,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -165,8 +165,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -190,8 +190,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -215,8 +215,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -240,8 +240,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -265,8 +265,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -290,8 +290,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -315,8 +315,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -340,8 +340,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -365,8 +365,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -390,8 +390,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -415,8 +415,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -440,8 +440,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -465,8 +465,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -490,8 +490,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -515,8 +515,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -540,8 +540,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -565,8 +565,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -590,8 +590,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -615,8 +615,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -634,13 +634,13 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50306611",
       "role": {
-        "lang:zh_TW": "雲林縣縣長",
-        "lang:en_US": "Mayor of Yunlin County"
+        "lang:zh-tw": "雲林縣縣長",
+        "lang:en": "Mayor of Yunlin County"
       }
     }
   ]

--- a/executive/Q15909984/current/popolo-m17n.json
+++ b/executive/Q15909984/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -47,8 +47,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -72,8 +72,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -97,8 +97,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -122,8 +122,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -147,8 +147,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -172,8 +172,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -197,8 +197,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -222,8 +222,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -247,8 +247,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -272,8 +272,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -297,8 +297,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -322,8 +322,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -347,8 +347,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -372,8 +372,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -397,8 +397,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -422,8 +422,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -447,8 +447,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -472,8 +472,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -497,8 +497,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -522,8 +522,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -547,8 +547,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -572,8 +572,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",

--- a/executive/Q16976490/current/popolo-m17n.json
+++ b/executive/Q16976490/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "陳福海",
-        "lang:en_US": "Chen Fu-hai"
+        "lang:zh-tw": "陳福海",
+        "lang:en": "Chen Fu-hai"
       },
       "id": "Q8984370",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "金門縣政府",
-        "lang:en_US": "Kinmen County Government"
+        "lang:zh-tw": "金門縣政府",
+        "lang:en": "Kinmen County Government"
       },
       "id": "Q16976490",
       "classification": "branch",
@@ -51,8 +51,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -76,8 +76,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -101,8 +101,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -126,8 +126,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -151,8 +151,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -176,8 +176,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -201,8 +201,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -226,8 +226,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -251,8 +251,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -276,8 +276,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -301,8 +301,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -326,8 +326,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -351,8 +351,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -376,8 +376,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -401,8 +401,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -426,8 +426,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -451,8 +451,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -476,8 +476,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -501,8 +501,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -526,8 +526,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -551,8 +551,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -576,8 +576,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -601,8 +601,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -619,13 +619,13 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50294007",
       "role": {
-        "lang:zh_TW": "金門縣縣長",
-        "lang:en_US": "Mayor of Kinmen"
+        "lang:zh-tw": "金門縣縣長",
+        "lang:en": "Mayor of Kinmen"
       }
     }
   ]

--- a/executive/Q17011999/current/popolo-m17n.json
+++ b/executive/Q17011999/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -47,8 +47,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -72,8 +72,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -97,8 +97,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -122,8 +122,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -147,8 +147,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -172,8 +172,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -197,8 +197,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -222,8 +222,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -247,8 +247,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -272,8 +272,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -297,8 +297,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -322,8 +322,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -347,8 +347,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -372,8 +372,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -397,8 +397,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -422,8 +422,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -447,8 +447,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -472,8 +472,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -497,8 +497,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -522,8 +522,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -547,8 +547,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -572,8 +572,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",

--- a/executive/Q17500943/current/popolo-m17n.json
+++ b/executive/Q17500943/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "陳光復",
-        "lang:en_US": "Chen Kuang-fu"
+        "lang:zh-tw": "陳光復",
+        "lang:en": "Chen Kuang-fu"
       },
       "id": "Q8347192",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "澎湖縣政府",
-        "lang:en_US": "Penghu County Government"
+        "lang:zh-tw": "澎湖縣政府",
+        "lang:en": "Penghu County Government"
       },
       "id": "Q17500943",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -65,8 +65,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -90,8 +90,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -115,8 +115,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -140,8 +140,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -165,8 +165,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -190,8 +190,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -215,8 +215,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -240,8 +240,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -265,8 +265,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -290,8 +290,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -315,8 +315,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -340,8 +340,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -365,8 +365,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -390,8 +390,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -415,8 +415,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -440,8 +440,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -465,8 +465,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -490,8 +490,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -515,8 +515,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -540,8 +540,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -565,8 +565,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -590,8 +590,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -615,8 +615,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -634,13 +634,13 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50306294",
       "role": {
-        "lang:zh_TW": "澎湖縣縣長",
-        "lang:en_US": "Mayor of Penghu County"
+        "lang:zh-tw": "澎湖縣縣長",
+        "lang:en": "Mayor of Penghu County"
       }
     }
   ]

--- a/executive/Q18658204/current/popolo-m17n.json
+++ b/executive/Q18658204/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "黃健庭",
-        "lang:en_US": "Justin Huang"
+        "lang:zh-tw": "黃健庭",
+        "lang:en": "Justin Huang"
       },
       "id": "Q8274104",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "臺東縣政府",
-        "lang:en_US": "Taitung County Government"
+        "lang:zh-tw": "臺東縣政府",
+        "lang:en": "Taitung County Government"
       },
       "id": "Q18658204",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -65,8 +65,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -90,8 +90,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -115,8 +115,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -140,8 +140,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -165,8 +165,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -190,8 +190,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -215,8 +215,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -240,8 +240,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -265,8 +265,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -290,8 +290,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -315,8 +315,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -340,8 +340,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -365,8 +365,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -390,8 +390,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -415,8 +415,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -440,8 +440,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -465,8 +465,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -490,8 +490,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -515,8 +515,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -540,8 +540,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -565,8 +565,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -590,8 +590,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -615,8 +615,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -634,13 +634,13 @@
       "start_date": "2009-12-20",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50306440",
       "role": {
-        "lang:zh_TW": "臺東縣縣長",
-        "lang:en_US": "Mayor of Taitung County"
+        "lang:zh-tw": "臺東縣縣長",
+        "lang:en": "Mayor of Taitung County"
       }
     }
   ]

--- a/executive/Q18658266/current/popolo-m17n.json
+++ b/executive/Q18658266/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "傅崐萁",
-        "lang:en_US": "Fu Kun-chi"
+        "lang:zh-tw": "傅崐萁",
+        "lang:en": "Fu Kun-chi"
       },
       "id": "Q8956378",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "花蓮縣政府",
-        "lang:en_US": "Hualien County Government"
+        "lang:zh-tw": "花蓮縣政府",
+        "lang:en": "Hualien County Government"
       },
       "id": "Q18658266",
       "classification": "branch",
@@ -51,8 +51,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -76,8 +76,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -101,8 +101,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -126,8 +126,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -151,8 +151,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -176,8 +176,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -201,8 +201,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -226,8 +226,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -251,8 +251,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -276,8 +276,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -301,8 +301,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -326,8 +326,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -351,8 +351,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -376,8 +376,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -401,8 +401,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -426,8 +426,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -451,8 +451,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -476,8 +476,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -501,8 +501,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -526,8 +526,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -551,8 +551,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -576,8 +576,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -601,8 +601,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -619,13 +619,13 @@
       "start_date": "2009-12-20",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50293691",
       "role": {
-        "lang:zh_TW": "花蓮縣縣長",
-        "lang:en_US": "Mayor of Hualien"
+        "lang:zh-tw": "花蓮縣縣長",
+        "lang:en": "Mayor of Hualien"
       }
     }
   ]

--- a/executive/Q50306736/current/popolo-m17n.json
+++ b/executive/Q50306736/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "鄭文燦",
-        "lang:en_US": "Cheng Wen-tsan"
+        "lang:zh-tw": "鄭文燦",
+        "lang:en": "Cheng Wen-tsan"
       },
       "id": "Q8349465",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "桃園市政府",
-        "lang:en_US": "Taoyuan City Government"
+        "lang:zh-tw": "桃園市政府",
+        "lang:en": "Taoyuan City Government"
       },
       "id": "Q50306736",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -68,8 +68,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -93,8 +93,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -118,8 +118,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -143,8 +143,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -168,8 +168,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -193,8 +193,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -218,8 +218,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -243,8 +243,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -268,8 +268,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -293,8 +293,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -318,8 +318,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -343,8 +343,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -368,8 +368,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -393,8 +393,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -418,8 +418,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -443,8 +443,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -468,8 +468,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -493,8 +493,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -518,8 +518,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -543,8 +543,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -568,8 +568,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -593,8 +593,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -618,8 +618,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -637,13 +637,13 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50306671",
       "role": {
-        "lang:zh_TW": "桃園市市長",
-        "lang:en_US": "Mayor of Taoyuan County"
+        "lang:zh-tw": "桃園市市長",
+        "lang:en": "Mayor of Taoyuan County"
       }
     }
   ]

--- a/executive/Q6366077/current/popolo-m17n.json
+++ b/executive/Q6366077/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "陳菊",
-        "lang:en_US": "Chen Chu"
+        "lang:zh-tw": "陳菊",
+        "lang:en": "Chen Chu"
       },
       "id": "Q465280",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "高雄市政府",
-        "lang:en_US": "Kaohsiung City Government"
+        "lang:zh-tw": "高雄市政府",
+        "lang:en": "Kaohsiung City Government"
       },
       "id": "Q6366077",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -65,8 +65,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -90,8 +90,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -115,8 +115,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -140,8 +140,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -165,8 +165,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -190,8 +190,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -215,8 +215,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -240,8 +240,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -265,8 +265,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -290,8 +290,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -315,8 +315,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -340,8 +340,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -365,8 +365,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -390,8 +390,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -415,8 +415,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -440,8 +440,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -465,8 +465,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -490,8 +490,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -515,8 +515,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -540,8 +540,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -565,8 +565,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -590,8 +590,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -615,8 +615,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -634,13 +634,13 @@
       "start_date": "2010-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50293830",
       "role": {
-        "lang:zh_TW": "高雄市市長",
-        "lang:en_US": "Mayor of Kaohsiung"
+        "lang:zh-tw": "高雄市市長",
+        "lang:en": "Mayor of Kaohsiung"
       }
     }
   ]

--- a/executive/Q715055/current/popolo-m17n.json
+++ b/executive/Q715055/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "顧維鈞",
-        "lang:en_US": "Wellington Koo"
+        "lang:zh-tw": "顧維鈞",
+        "lang:en": "Wellington Koo"
       },
       "id": "Q317462",
       "identifiers": [
@@ -18,8 +18,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴清德",
-        "lang:en_US": "William Lai"
+        "lang:zh-tw": "賴清德",
+        "lang:en": "William Lai"
       },
       "id": "Q3847080",
       "identifiers": [
@@ -37,7 +37,7 @@
     },
     {
       "name": {
-        "lang:en_US": "Wang Zhengting"
+        "lang:en": "Wang Zhengting"
       },
       "id": "Q6127766",
       "identifiers": [
@@ -52,7 +52,7 @@
     },
     {
       "name": {
-        "lang:en_US": "Xiong Xiling"
+        "lang:en": "Xiong Xiling"
       },
       "id": "Q6130548",
       "identifiers": [
@@ -69,8 +69,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "行政院",
-        "lang:en_US": "Executive Yuan"
+        "lang:zh-tw": "行政院",
+        "lang:en": "Executive Yuan"
       },
       "id": "Q715055",
       "classification": "branch",
@@ -84,8 +84,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -98,8 +98,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -112,8 +112,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國同盟會",
-        "lang:en_US": "Tongmenghui"
+        "lang:zh-tw": "中國同盟會",
+        "lang:en": "Tongmenghui"
       },
       "id": "Q950326",
       "classification": "party",
@@ -142,8 +142,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -160,13 +160,13 @@
       "area_id": "Q865",
       "role_superclass_code": "Q702650",
       "role_superclass": {
-        "lang:zh_TW": "台灣行政院院長",
-        "lang:en_US": "President of the Executive Yuan"
+        "lang:zh-tw": "台灣行政院院長",
+        "lang:en": "President of the Executive Yuan"
       },
       "role_code": "Q702650",
       "role": {
-        "lang:zh_TW": "台灣行政院院長",
-        "lang:en_US": "President of the Executive Yuan"
+        "lang:zh-tw": "台灣行政院院長",
+        "lang:en": "President of the Executive Yuan"
       }
     },
     {
@@ -178,13 +178,13 @@
       "start_date": "2017-09-08",
       "role_superclass_code": "Q702650",
       "role_superclass": {
-        "lang:zh_TW": "台灣行政院院長",
-        "lang:en_US": "President of the Executive Yuan"
+        "lang:zh-tw": "台灣行政院院長",
+        "lang:en": "President of the Executive Yuan"
       },
       "role_code": "Q702650",
       "role": {
-        "lang:zh_TW": "台灣行政院院長",
-        "lang:en_US": "President of the Executive Yuan"
+        "lang:zh-tw": "台灣行政院院長",
+        "lang:en": "President of the Executive Yuan"
       }
     },
     {
@@ -195,13 +195,13 @@
       "area_id": "Q865",
       "role_superclass_code": "Q702650",
       "role_superclass": {
-        "lang:zh_TW": "台灣行政院院長",
-        "lang:en_US": "President of the Executive Yuan"
+        "lang:zh-tw": "台灣行政院院長",
+        "lang:en": "President of the Executive Yuan"
       },
       "role_code": "Q702650",
       "role": {
-        "lang:zh_TW": "台灣行政院院長",
-        "lang:en_US": "President of the Executive Yuan"
+        "lang:zh-tw": "台灣行政院院長",
+        "lang:en": "President of the Executive Yuan"
       }
     },
     {
@@ -212,13 +212,13 @@
       "area_id": "Q865",
       "role_superclass_code": "Q702650",
       "role_superclass": {
-        "lang:zh_TW": "台灣行政院院長",
-        "lang:en_US": "President of the Executive Yuan"
+        "lang:zh-tw": "台灣行政院院長",
+        "lang:en": "President of the Executive Yuan"
       },
       "role_code": "Q702650",
       "role": {
-        "lang:zh_TW": "台灣行政院院長",
-        "lang:en_US": "President of the Executive Yuan"
+        "lang:zh-tw": "台灣行政院院長",
+        "lang:en": "President of the Executive Yuan"
       }
     },
     {
@@ -228,13 +228,13 @@
       "area_id": "Q865",
       "role_superclass_code": "Q702650",
       "role_superclass": {
-        "lang:zh_TW": "台灣行政院院長",
-        "lang:en_US": "President of the Executive Yuan"
+        "lang:zh-tw": "台灣行政院院長",
+        "lang:en": "President of the Executive Yuan"
       },
       "role_code": "Q702650",
       "role": {
-        "lang:zh_TW": "台灣行政院院長",
-        "lang:en_US": "President of the Executive Yuan"
+        "lang:zh-tw": "台灣行政院院長",
+        "lang:en": "President of the Executive Yuan"
       }
     }
   ]

--- a/executive/Q7676194/current/popolo-m17n.json
+++ b/executive/Q7676194/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "李孟諺",
-        "lang:en_US": "Lee Meng-yen"
+        "lang:zh-tw": "李孟諺",
+        "lang:en": "Lee Meng-yen"
       },
       "id": "Q38876935",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "臺南市政府",
-        "lang:en_US": "Tainan City Government"
+        "lang:zh-tw": "臺南市政府",
+        "lang:en": "Tainan City Government"
       },
       "id": "Q7676194",
       "classification": "branch",
@@ -51,8 +51,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -76,8 +76,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -101,8 +101,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -126,8 +126,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -151,8 +151,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -176,8 +176,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -201,8 +201,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -226,8 +226,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -251,8 +251,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -276,8 +276,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -301,8 +301,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -326,8 +326,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -351,8 +351,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -376,8 +376,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -401,8 +401,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -426,8 +426,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -451,8 +451,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -476,8 +476,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -501,8 +501,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -526,8 +526,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -551,8 +551,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -576,8 +576,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -601,8 +601,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -619,13 +619,13 @@
       "start_date": "2017-09-07",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q50293073",
       "role": {
-        "lang:zh_TW": "臺南市市長",
-        "lang:en_US": "Mayor of Tainan"
+        "lang:zh-tw": "臺南市市長",
+        "lang:en": "Mayor of Tainan"
       }
     }
   ]

--- a/executive/Q9105560/current/popolo-m17n.json
+++ b/executive/Q9105560/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "柯文哲",
-        "lang:en_US": "Ko Wen-je"
+        "lang:zh-tw": "柯文哲",
+        "lang:en": "Ko Wen-je"
       },
       "id": "Q18113714",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "臺北市政府",
-        "lang:en_US": "Taipei City Government"
+        "lang:zh-tw": "臺北市政府",
+        "lang:en": "Taipei City Government"
       },
       "id": "Q9105560",
       "classification": "branch",
@@ -54,8 +54,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -79,8 +79,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -104,8 +104,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -129,8 +129,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -154,8 +154,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -179,8 +179,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -204,8 +204,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -229,8 +229,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -254,8 +254,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -279,8 +279,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -304,8 +304,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -329,8 +329,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -354,8 +354,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -379,8 +379,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -404,8 +404,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -429,8 +429,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -454,8 +454,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -479,8 +479,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -504,8 +504,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -529,8 +529,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -554,8 +554,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -579,8 +579,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -604,8 +604,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -622,13 +622,13 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:zh_TW": "市長",
-        "lang:en_US": "mayor"
+        "lang:zh-tw": "市長",
+        "lang:en": "mayor"
       },
       "role_code": "Q6310674",
       "role": {
-        "lang:zh_TW": "臺北市市長",
-        "lang:en_US": "Mayor of Taipei"
+        "lang:zh-tw": "臺北市市長",
+        "lang:en": "Mayor of Taipei"
       }
     }
   ]

--- a/legislative/Q10907927/Q49995759/popolo-m17n.json
+++ b/legislative/Q10907927/Q49995759/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "陳翰立"
+        "lang:zh-tw": "陳翰立"
       },
       "id": "Q16908019",
       "identifiers": [
@@ -17,8 +17,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳國昌",
-        "lang:en_US": "Antonio Ng"
+        "lang:zh-tw": "吳國昌",
+        "lang:en": "Antonio Ng"
       },
       "id": "Q4776833",
       "identifiers": [
@@ -33,7 +33,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡宗智"
+        "lang:zh-tw": "蔡宗智"
       },
       "id": "Q50018270",
       "identifiers": [
@@ -48,7 +48,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "莊文斌"
+        "lang:zh-tw": "莊文斌"
       },
       "id": "Q50018356",
       "identifiers": [
@@ -63,7 +63,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪明科"
+        "lang:zh-tw": "洪明科"
       },
       "id": "Q50018440",
       "identifiers": [
@@ -78,7 +78,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "游宏達"
+        "lang:zh-tw": "游宏達"
       },
       "id": "Q50018530",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張維華"
+        "lang:zh-tw": "張維華"
       },
       "id": "Q50018615",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾振炎"
+        "lang:zh-tw": "曾振炎"
       },
       "id": "Q50018721",
       "identifiers": [
@@ -123,7 +123,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "于秀英"
+        "lang:zh-tw": "于秀英"
       },
       "id": "Q50018971",
       "identifiers": [
@@ -138,7 +138,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃文君"
+        "lang:zh-tw": "黃文君"
       },
       "id": "Q50019060",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李洲忠"
+        "lang:zh-tw": "李洲忠"
       },
       "id": "Q50019164",
       "identifiers": [
@@ -168,7 +168,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "簡景賢"
+        "lang:zh-tw": "簡景賢"
       },
       "id": "Q50019257",
       "identifiers": [
@@ -183,7 +183,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "簡峻庭"
+        "lang:zh-tw": "簡峻庭"
       },
       "id": "Q50019344",
       "identifiers": [
@@ -198,7 +198,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "簡賜勝"
+        "lang:zh-tw": "簡賜勝"
       },
       "id": "Q50019437",
       "identifiers": [
@@ -213,7 +213,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖梓佑"
+        "lang:zh-tw": "廖梓佑"
       },
       "id": "Q50019522",
       "identifiers": [
@@ -228,7 +228,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林永鴻"
+        "lang:zh-tw": "林永鴻"
       },
       "id": "Q50019612",
       "identifiers": [
@@ -243,7 +243,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖宜賢"
+        "lang:zh-tw": "廖宜賢"
       },
       "id": "Q50019691",
       "identifiers": [
@@ -258,7 +258,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳昭煜"
+        "lang:zh-tw": "陳昭煜"
       },
       "id": "Q50019776",
       "identifiers": [
@@ -273,7 +273,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蕭志全"
+        "lang:zh-tw": "蕭志全"
       },
       "id": "Q50019853",
       "identifiers": [
@@ -288,7 +288,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳淑惠"
+        "lang:zh-tw": "陳淑惠"
       },
       "id": "Q50019923",
       "identifiers": [
@@ -303,7 +303,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝明謀"
+        "lang:zh-tw": "謝明謀"
       },
       "id": "Q50019996",
       "identifiers": [
@@ -318,7 +318,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許素霞"
+        "lang:zh-tw": "許素霞"
       },
       "id": "Q50020073",
       "identifiers": [
@@ -333,7 +333,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡宜助"
+        "lang:zh-tw": "蔡宜助"
       },
       "id": "Q50020137",
       "identifiers": [
@@ -348,7 +348,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張志銘"
+        "lang:zh-tw": "張志銘"
       },
       "id": "Q50020207",
       "identifiers": [
@@ -363,7 +363,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何勝豐"
+        "lang:zh-tw": "何勝豐"
       },
       "id": "Q50020278",
       "identifiers": [
@@ -378,7 +378,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳瑞芳"
+        "lang:zh-tw": "吳瑞芳"
       },
       "id": "Q50020361",
       "identifiers": [
@@ -393,7 +393,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "潘一全"
+        "lang:zh-tw": "潘一全"
       },
       "id": "Q50020444",
       "identifiers": [
@@ -408,7 +408,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林芳伃"
+        "lang:zh-tw": "林芳伃"
       },
       "id": "Q50020530",
       "identifiers": [
@@ -423,7 +423,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱美玲"
+        "lang:zh-tw": "邱美玲"
       },
       "id": "Q50020616",
       "identifiers": [
@@ -438,7 +438,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖志城"
+        "lang:zh-tw": "廖志城"
       },
       "id": "Q50020679",
       "identifiers": [
@@ -453,7 +453,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許阿甘"
+        "lang:zh-tw": "許阿甘"
       },
       "id": "Q50020736",
       "identifiers": [
@@ -468,7 +468,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王彩雲"
+        "lang:zh-tw": "王彩雲"
       },
       "id": "Q50020855",
       "identifiers": [
@@ -483,7 +483,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "石慶龍"
+        "lang:zh-tw": "石慶龍"
       },
       "id": "Q50020904",
       "identifiers": [
@@ -498,7 +498,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "史清水"
+        "lang:zh-tw": "史清水"
       },
       "id": "Q50020926",
       "identifiers": [
@@ -513,7 +513,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖文賢"
+        "lang:zh-tw": "廖文賢"
       },
       "id": "Q50020956",
       "identifiers": [
@@ -528,7 +528,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴燕雪"
+        "lang:zh-tw": "賴燕雪"
       },
       "id": "Q8350007",
       "identifiers": [
@@ -543,7 +543,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅美玲"
+        "lang:zh-tw": "羅美玲"
       },
       "id": "Q8988903",
       "identifiers": [
@@ -560,8 +560,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "南投縣議會",
-        "lang:en_US": "Nantou County Council"
+        "lang:zh-tw": "南投縣議會",
+        "lang:en": "Nantou County Council"
       },
       "id": "Q10907927",
       "classification": "branch",
@@ -578,8 +578,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -592,7 +592,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "臺灣第一民族黨"
+        "lang:zh-tw": "臺灣第一民族黨"
       },
       "id": "Q50059206",
       "classification": "party",
@@ -605,8 +605,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -635,8 +635,8 @@
         "Q49254306"
       ],
       "type": {
-        "lang:zh_TW": "南投縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Nantou County"
+        "lang:zh-tw": "南投縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
         "lang:zh_TW": "南投縣第01選區"
@@ -659,8 +659,8 @@
         "Q49254306"
       ],
       "type": {
-        "lang:zh_TW": "南投縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Nantou County"
+        "lang:zh-tw": "南投縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
         "lang:zh_TW": "南投縣第02選區"
@@ -683,8 +683,8 @@
         "Q49254306"
       ],
       "type": {
-        "lang:zh_TW": "南投縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Nantou County"
+        "lang:zh-tw": "南投縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
         "lang:zh_TW": "南投縣第03選區"
@@ -707,8 +707,8 @@
         "Q49254306"
       ],
       "type": {
-        "lang:zh_TW": "南投縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Nantou County"
+        "lang:zh-tw": "南投縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
         "lang:zh_TW": "南投縣第04選區"
@@ -731,8 +731,8 @@
         "Q49254306"
       ],
       "type": {
-        "lang:zh_TW": "南投縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Nantou County"
+        "lang:zh-tw": "南投縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
         "lang:zh_TW": "南投縣第05選區"
@@ -755,8 +755,8 @@
         "Q49254306"
       ],
       "type": {
-        "lang:zh_TW": "南投縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Nantou County"
+        "lang:zh-tw": "南投縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
         "lang:zh_TW": "南投縣第06選區"
@@ -779,8 +779,8 @@
         "Q49254306"
       ],
       "type": {
-        "lang:zh_TW": "南投縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Nantou County"
+        "lang:zh-tw": "南投縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
         "lang:zh_TW": "南投縣第07選區"
@@ -803,8 +803,8 @@
         "Q49254306"
       ],
       "type": {
-        "lang:zh_TW": "南投縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Nantou County"
+        "lang:zh-tw": "南投縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
         "lang:zh_TW": "南投縣第08選區"
@@ -827,8 +827,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -852,8 +852,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -872,12 +872,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -888,12 +888,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -904,12 +904,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -921,12 +921,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -937,12 +937,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -953,12 +953,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -970,12 +970,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -987,12 +987,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1003,12 +1003,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1019,12 +1019,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1036,12 +1036,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1053,12 +1053,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1069,12 +1069,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1085,12 +1085,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1102,12 +1102,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1119,12 +1119,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1136,12 +1136,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1153,12 +1153,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1170,12 +1170,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1187,12 +1187,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1204,12 +1204,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1221,12 +1221,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1238,12 +1238,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1255,12 +1255,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1272,12 +1272,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1288,12 +1288,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1305,12 +1305,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1322,12 +1322,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1339,12 +1339,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1356,12 +1356,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1373,12 +1373,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1390,12 +1390,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1407,12 +1407,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1424,12 +1424,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1440,12 +1440,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1457,12 +1457,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     },
     {
@@ -1473,12 +1473,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254306",
       "role": {
-        "lang:zh_TW": "南投縣議員"
+        "lang:zh-tw": "南投縣議員"
       }
     }
   ]

--- a/legislative/Q10924120/Q49995848/popolo-m17n.json
+++ b/legislative/Q10924120/Q49995848/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "張秀華"
+        "lang:zh-tw": "張秀華"
       },
       "id": "Q15951827",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蕭淑麗"
+        "lang:zh-tw": "蕭淑麗"
       },
       "id": "Q24836821",
       "identifiers": [
@@ -32,8 +32,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "戴寧",
-        "lang:en_US": "Dai Ning"
+        "lang:zh-tw": "戴寧",
+        "lang:en": "Dai Ning"
       },
       "id": "Q45554545",
       "identifiers": [
@@ -48,7 +48,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "傅大偉"
+        "lang:zh-tw": "傅大偉"
       },
       "id": "Q50021008",
       "identifiers": [
@@ -63,7 +63,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭明賓"
+        "lang:zh-tw": "郭明賓"
       },
       "id": "Q50043666",
       "identifiers": [
@@ -78,7 +78,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張榮藏"
+        "lang:zh-tw": "張榮藏"
       },
       "id": "Q50043692",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪有仁"
+        "lang:zh-tw": "洪有仁"
       },
       "id": "Q50043718",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃盈智"
+        "lang:zh-tw": "黃盈智"
       },
       "id": "Q50059876",
       "identifiers": [
@@ -123,7 +123,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃露慧"
+        "lang:zh-tw": "黃露慧"
       },
       "id": "Q50059948",
       "identifiers": [
@@ -138,7 +138,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃秋澤"
+        "lang:zh-tw": "黃秋澤"
       },
       "id": "Q50059993",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭文居"
+        "lang:zh-tw": "郭文居"
       },
       "id": "Q50060037",
       "identifiers": [
@@ -168,7 +168,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張敏琪"
+        "lang:zh-tw": "張敏琪"
       },
       "id": "Q50060107",
       "identifiers": [
@@ -183,7 +183,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡永泉"
+        "lang:zh-tw": "蔡永泉"
       },
       "id": "Q50060144",
       "identifiers": [
@@ -198,7 +198,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳幸枝"
+        "lang:zh-tw": "陳幸枝"
       },
       "id": "Q50060187",
       "identifiers": [
@@ -213,7 +213,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖天隆"
+        "lang:zh-tw": "廖天隆"
       },
       "id": "Q50060221",
       "identifiers": [
@@ -228,7 +228,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳姿妏"
+        "lang:zh-tw": "陳姿妏"
       },
       "id": "Q50060248",
       "identifiers": [
@@ -243,7 +243,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李忠曆"
+        "lang:zh-tw": "李忠曆"
       },
       "id": "Q50060287",
       "identifiers": [
@@ -258,7 +258,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王美惠"
+        "lang:zh-tw": "王美惠"
       },
       "id": "Q50060352",
       "identifiers": [
@@ -273,7 +273,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇澤峰"
+        "lang:zh-tw": "蘇澤峰"
       },
       "id": "Q50060397",
       "identifiers": [
@@ -288,7 +288,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳上明"
+        "lang:zh-tw": "吳上明"
       },
       "id": "Q50060440",
       "identifiers": [
@@ -303,7 +303,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "莊豐安"
+        "lang:zh-tw": "莊豐安"
       },
       "id": "Q50060471",
       "identifiers": [
@@ -318,7 +318,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡榮豐"
+        "lang:zh-tw": "蔡榮豐"
       },
       "id": "Q50060507",
       "identifiers": [
@@ -333,7 +333,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭光宏"
+        "lang:zh-tw": "鄭光宏"
       },
       "id": "Q50060543",
       "identifiers": [
@@ -348,7 +348,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡文旭"
+        "lang:zh-tw": "蔡文旭"
       },
       "id": "Q50060580",
       "identifiers": [
@@ -365,8 +365,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "嘉義市議會",
-        "lang:en_US": "Chiayi City Council"
+        "lang:zh-tw": "嘉義市議會",
+        "lang:en": "Chiayi City Council"
       },
       "id": "Q10924120",
       "classification": "branch",
@@ -383,8 +383,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -397,8 +397,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "台灣團結聯盟",
-        "lang:en_US": "Taiwan Solidarity Union"
+        "lang:zh-tw": "台灣團結聯盟",
+        "lang:en": "Taiwan Solidarity Union"
       },
       "id": "Q706834",
       "classification": "party",
@@ -411,8 +411,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -441,8 +441,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -466,8 +466,8 @@
         "Q49254452"
       ],
       "type": {
-        "lang:zh_TW": "嘉義市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Chiayi City"
+        "lang:zh-tw": "嘉義市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Chiayi City"
       },
       "name": {
         "lang:zh_TW": "嘉義市第01選區"
@@ -490,8 +490,8 @@
         "Q49254452"
       ],
       "type": {
-        "lang:zh_TW": "嘉義市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Chiayi City"
+        "lang:zh-tw": "嘉義市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Chiayi City"
       },
       "name": {
         "lang:zh_TW": "嘉義市第02選區"
@@ -514,8 +514,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -534,12 +534,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -550,12 +550,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -566,12 +566,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -583,12 +583,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -600,12 +600,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -617,12 +617,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -633,12 +633,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -650,12 +650,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -667,12 +667,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -683,12 +683,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -700,12 +700,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -717,12 +717,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -734,12 +734,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -751,12 +751,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -767,12 +767,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -783,12 +783,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -799,12 +799,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -816,12 +816,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -832,12 +832,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -848,12 +848,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -864,12 +864,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -880,12 +880,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -897,12 +897,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     },
     {
@@ -914,12 +914,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254452",
       "role": {
-        "lang:zh_TW": "嘉義市議員"
+        "lang:zh-tw": "嘉義市議員"
       }
     }
   ]

--- a/legislative/Q10924150/Q49995901/popolo-m17n.json
+++ b/legislative/Q10924150/Q49995901/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "黃嫈珺"
+        "lang:zh-tw": "黃嫈珺"
       },
       "id": "Q18119503",
       "identifiers": [
@@ -17,8 +17,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳福成",
-        "lang:en_US": "Chen Fucheng"
+        "lang:zh-tw": "陳福成",
+        "lang:en": "Chen Fucheng"
       },
       "id": "Q45566349",
       "identifiers": [
@@ -33,7 +33,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張明達"
+        "lang:zh-tw": "張明達"
       },
       "id": "Q47545890",
       "identifiers": [
@@ -48,7 +48,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "戴光宗"
+        "lang:zh-tw": "戴光宗"
       },
       "id": "Q50060653",
       "identifiers": [
@@ -63,7 +63,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林沐惠"
+        "lang:zh-tw": "林沐惠"
       },
       "id": "Q50060757",
       "identifiers": [
@@ -78,7 +78,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王啓澧"
+        "lang:zh-tw": "王啓澧"
       },
       "id": "Q50060811",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "詹琬蓁"
+        "lang:zh-tw": "詹琬蓁"
       },
       "id": "Q50060850",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "董國誠"
+        "lang:zh-tw": "董國誠"
       },
       "id": "Q50060885",
       "identifiers": [
@@ -123,7 +123,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林緗亭"
+        "lang:zh-tw": "林緗亭"
       },
       "id": "Q50060925",
       "identifiers": [
@@ -138,7 +138,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳文忠"
+        "lang:zh-tw": "陳文忠"
       },
       "id": "Q50060999",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "葉孟龍"
+        "lang:zh-tw": "葉孟龍"
       },
       "id": "Q50061082",
       "identifiers": [
@@ -168,7 +168,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃芳蘭"
+        "lang:zh-tw": "黃芳蘭"
       },
       "id": "Q50061127",
       "identifiers": [
@@ -183,7 +183,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林于玲"
+        "lang:zh-tw": "林于玲"
       },
       "id": "Q50061197",
       "identifiers": [
@@ -198,7 +198,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴朝崙"
+        "lang:zh-tw": "賴朝崙"
       },
       "id": "Q50061245",
       "identifiers": [
@@ -213,7 +213,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "詹金繪"
+        "lang:zh-tw": "詹金繪"
       },
       "id": "Q50061332",
       "identifiers": [
@@ -228,7 +228,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳思蓉"
+        "lang:zh-tw": "吳思蓉"
       },
       "id": "Q50061375",
       "identifiers": [
@@ -243,7 +243,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭芳宜"
+        "lang:zh-tw": "郭芳宜"
       },
       "id": "Q50061413",
       "identifiers": [
@@ -258,7 +258,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "葉和平"
+        "lang:zh-tw": "葉和平"
       },
       "id": "Q50061449",
       "identifiers": [
@@ -273,7 +273,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳保仁"
+        "lang:zh-tw": "陳保仁"
       },
       "id": "Q50061488",
       "identifiers": [
@@ -288,7 +288,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃錦成"
+        "lang:zh-tw": "黃錦成"
       },
       "id": "Q50061531",
       "identifiers": [
@@ -303,7 +303,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡奇璋"
+        "lang:zh-tw": "蔡奇璋"
       },
       "id": "Q50061570",
       "identifiers": [
@@ -318,7 +318,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李國勝"
+        "lang:zh-tw": "李國勝"
       },
       "id": "Q50061614",
       "identifiers": [
@@ -333,7 +333,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡鼎三"
+        "lang:zh-tw": "蔡鼎三"
       },
       "id": "Q50061658",
       "identifiers": [
@@ -348,7 +348,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳怡岳"
+        "lang:zh-tw": "陳怡岳"
       },
       "id": "Q50061734",
       "identifiers": [
@@ -363,7 +363,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃金茂"
+        "lang:zh-tw": "黃金茂"
       },
       "id": "Q50061811",
       "identifiers": [
@@ -378,7 +378,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡信典"
+        "lang:zh-tw": "蔡信典"
       },
       "id": "Q50061855",
       "identifiers": [
@@ -393,7 +393,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡瑋傑"
+        "lang:zh-tw": "蔡瑋傑"
       },
       "id": "Q50061886",
       "identifiers": [
@@ -408,7 +408,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "詹黃素蓮"
+        "lang:zh-tw": "詹黃素蓮"
       },
       "id": "Q50061967",
       "identifiers": [
@@ -423,7 +423,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅士洋"
+        "lang:zh-tw": "羅士洋"
       },
       "id": "Q50062007",
       "identifiers": [
@@ -438,7 +438,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張貴忠"
+        "lang:zh-tw": "張貴忠"
       },
       "id": "Q50062049",
       "identifiers": [
@@ -453,7 +453,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾亮哲"
+        "lang:zh-tw": "曾亮哲"
       },
       "id": "Q50062096",
       "identifiers": [
@@ -468,7 +468,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何子凡"
+        "lang:zh-tw": "何子凡"
       },
       "id": "Q50062140",
       "identifiers": [
@@ -483,7 +483,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳柏麟"
+        "lang:zh-tw": "陳柏麟"
       },
       "id": "Q50062171",
       "identifiers": [
@@ -498,7 +498,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "石信忠"
+        "lang:zh-tw": "石信忠"
       },
       "id": "Q50062205",
       "identifiers": [
@@ -513,7 +513,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林寶瓶"
+        "lang:zh-tw": "林寶瓶"
       },
       "id": "Q50184126",
       "identifiers": [
@@ -528,7 +528,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林秀琴"
+        "lang:zh-tw": "林秀琴"
       },
       "id": "Q50184266",
       "identifiers": [
@@ -543,7 +543,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "姜梅紅"
+        "lang:zh-tw": "姜梅紅"
       },
       "id": "Q8975499",
       "identifiers": [
@@ -560,8 +560,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "嘉義縣議會",
-        "lang:en_US": "Chiayi County Council"
+        "lang:zh-tw": "嘉義縣議會",
+        "lang:en": "Chiayi County Council"
       },
       "id": "Q10924150",
       "classification": "branch",
@@ -578,8 +578,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -592,8 +592,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -622,8 +622,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -647,8 +647,8 @@
         "Q49254596"
       ],
       "type": {
-        "lang:zh_TW": "嘉義縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Chiayi County"
+        "lang:zh-tw": "嘉義縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
         "lang:zh_TW": "嘉義縣第01選區"
@@ -671,8 +671,8 @@
         "Q49254596"
       ],
       "type": {
-        "lang:zh_TW": "嘉義縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Chiayi County"
+        "lang:zh-tw": "嘉義縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
         "lang:zh_TW": "嘉義縣第02選區"
@@ -695,8 +695,8 @@
         "Q49254596"
       ],
       "type": {
-        "lang:zh_TW": "嘉義縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Chiayi County"
+        "lang:zh-tw": "嘉義縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
         "lang:zh_TW": "嘉義縣第03選區"
@@ -719,8 +719,8 @@
         "Q49254596"
       ],
       "type": {
-        "lang:zh_TW": "嘉義縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Chiayi County"
+        "lang:zh-tw": "嘉義縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
         "lang:zh_TW": "嘉義縣第04選區"
@@ -743,8 +743,8 @@
         "Q49254596"
       ],
       "type": {
-        "lang:zh_TW": "嘉義縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Chiayi County"
+        "lang:zh-tw": "嘉義縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
         "lang:zh_TW": "嘉義縣第05選區"
@@ -767,8 +767,8 @@
         "Q49254596"
       ],
       "type": {
-        "lang:zh_TW": "嘉義縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Chiayi County"
+        "lang:zh-tw": "嘉義縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
         "lang:zh_TW": "嘉義縣第06選區"
@@ -791,8 +791,8 @@
         "Q49254596"
       ],
       "type": {
-        "lang:zh_TW": "嘉義縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Chiayi County"
+        "lang:zh-tw": "嘉義縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
         "lang:zh_TW": "嘉義縣第07選區"
@@ -815,8 +815,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -835,12 +835,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -851,12 +851,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -868,12 +868,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -885,12 +885,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -902,12 +902,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -918,12 +918,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -934,12 +934,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -950,12 +950,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -967,12 +967,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -983,12 +983,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1000,12 +1000,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1016,12 +1016,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1033,12 +1033,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1049,12 +1049,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1066,12 +1066,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1083,12 +1083,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1100,12 +1100,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1117,12 +1117,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1135,12 +1135,12 @@
       "end_date": "2017-01-27",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1153,12 +1153,12 @@
       "end_date": "2015-06-02",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1170,12 +1170,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1187,12 +1187,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1204,12 +1204,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1221,12 +1221,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1238,12 +1238,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1254,12 +1254,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1271,12 +1271,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1288,12 +1288,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1305,12 +1305,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1322,12 +1322,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1339,12 +1339,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1355,12 +1355,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1372,12 +1372,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1388,12 +1388,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1405,12 +1405,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1422,12 +1422,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     },
     {
@@ -1438,12 +1438,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254596",
       "role": {
-        "lang:zh_TW": "嘉義縣議員"
+        "lang:zh-tw": "嘉義縣議員"
       }
     }
   ]

--- a/legislative/Q10930444/Q50178994/popolo-m17n.json
+++ b/legislative/Q10930444/Q50178994/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "施世明"
+        "lang:zh-tw": "施世明"
       },
       "id": "Q18234376",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "宋瑋莉"
+        "lang:zh-tw": "宋瑋莉"
       },
       "id": "Q21652185",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "藍敏煌"
+        "lang:zh-tw": "藍敏煌"
       },
       "id": "Q50062244",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "詹春陽"
+        "lang:zh-tw": "詹春陽"
       },
       "id": "Q50062310",
       "identifiers": [
@@ -62,7 +62,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "呂美玲"
+        "lang:zh-tw": "呂美玲"
       },
       "id": "Q50062354",
       "identifiers": [
@@ -77,7 +77,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張漢土"
+        "lang:zh-tw": "張漢土"
       },
       "id": "Q50062397",
       "identifiers": [
@@ -92,7 +92,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳東財"
+        "lang:zh-tw": "陳東財"
       },
       "id": "Q50062437",
       "identifiers": [
@@ -107,7 +107,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "韓良圻"
+        "lang:zh-tw": "韓良圻"
       },
       "id": "Q50062516",
       "identifiers": [
@@ -122,7 +122,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張芳麗"
+        "lang:zh-tw": "張芳麗"
       },
       "id": "Q50062561",
       "identifiers": [
@@ -137,7 +137,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "莊榮欽"
+        "lang:zh-tw": "莊榮欽"
       },
       "id": "Q50062604",
       "identifiers": [
@@ -152,7 +152,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾紀嚴"
+        "lang:zh-tw": "曾紀嚴"
       },
       "id": "Q50062651",
       "identifiers": [
@@ -167,7 +167,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊石城"
+        "lang:zh-tw": "楊石城"
       },
       "id": "Q50062800",
       "identifiers": [
@@ -182,7 +182,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張錦煌"
+        "lang:zh-tw": "張錦煌"
       },
       "id": "Q50062839",
       "identifiers": [
@@ -197,7 +197,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "秦鉦"
+        "lang:zh-tw": "秦鉦"
       },
       "id": "Q50062878",
       "identifiers": [
@@ -212,7 +212,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪森永"
+        "lang:zh-tw": "洪森永"
       },
       "id": "Q50062918",
       "identifiers": [
@@ -227,7 +227,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "莊錦田"
+        "lang:zh-tw": "莊錦田"
       },
       "id": "Q50062951",
       "identifiers": [
@@ -242,7 +242,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭林清良"
+        "lang:zh-tw": "鄭林清良"
       },
       "id": "Q50063003",
       "identifiers": [
@@ -257,7 +257,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳志成"
+        "lang:zh-tw": "陳志成"
       },
       "id": "Q50063045",
       "identifiers": [
@@ -272,7 +272,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "俞叁發"
+        "lang:zh-tw": "俞叁發"
       },
       "id": "Q50063090",
       "identifiers": [
@@ -287,7 +287,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "連恩典"
+        "lang:zh-tw": "連恩典"
       },
       "id": "Q50063128",
       "identifiers": [
@@ -302,7 +302,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林明智"
+        "lang:zh-tw": "林明智"
       },
       "id": "Q50063163",
       "identifiers": [
@@ -317,7 +317,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳江山"
+        "lang:zh-tw": "陳江山"
       },
       "id": "Q50063201",
       "identifiers": [
@@ -332,7 +332,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊秀玉"
+        "lang:zh-tw": "楊秀玉"
       },
       "id": "Q50063242",
       "identifiers": [
@@ -347,7 +347,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇仁和"
+        "lang:zh-tw": "蘇仁和"
       },
       "id": "Q50063278",
       "identifiers": [
@@ -362,7 +362,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡旺璉"
+        "lang:zh-tw": "蔡旺璉"
       },
       "id": "Q50063314",
       "identifiers": [
@@ -377,7 +377,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張耿輝"
+        "lang:zh-tw": "張耿輝"
       },
       "id": "Q50063353",
       "identifiers": [
@@ -392,7 +392,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳明建"
+        "lang:zh-tw": "陳明建"
       },
       "id": "Q50063384",
       "identifiers": [
@@ -407,7 +407,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何淑萍"
+        "lang:zh-tw": "何淑萍"
       },
       "id": "Q50184385",
       "identifiers": [
@@ -422,8 +422,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐莉莉",
-        "lang:en_US": "Xu Lili"
+        "lang:zh-tw": "徐莉莉",
+        "lang:en": "Xu Lili"
       },
       "id": "Q8248927",
       "identifiers": [
@@ -438,7 +438,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡適應"
+        "lang:zh-tw": "蔡適應"
       },
       "id": "Q8347638",
       "identifiers": [
@@ -453,7 +453,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "游祥耀"
+        "lang:zh-tw": "游祥耀"
       },
       "id": "Q8350712",
       "identifiers": [
@@ -470,8 +470,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "基隆市議會",
-        "lang:en_US": "Keelung City Council"
+        "lang:zh-tw": "基隆市議會",
+        "lang:en": "Keelung City Council"
       },
       "id": "Q10930444",
       "classification": "branch",
@@ -488,8 +488,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "親民黨",
-        "lang:en_US": "People First Party"
+        "lang:zh-tw": "親民黨",
+        "lang:en": "People First Party"
       },
       "id": "Q1442482",
       "classification": "party",
@@ -502,8 +502,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民國黨",
-        "lang:en_US": "Minkuotang"
+        "lang:zh-tw": "民國黨",
+        "lang:en": "Minkuotang"
       },
       "id": "Q19684454",
       "classification": "party",
@@ -516,8 +516,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -530,8 +530,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -560,8 +560,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -585,8 +585,8 @@
         "Q49254733"
       ],
       "type": {
-        "lang:zh_TW": "基隆市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Keelung"
+        "lang:zh-tw": "基隆市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
         "lang:zh_TW": "基隆市第01選區"
@@ -609,8 +609,8 @@
         "Q49254733"
       ],
       "type": {
-        "lang:zh_TW": "基隆市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Keelung"
+        "lang:zh-tw": "基隆市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
         "lang:zh_TW": "基隆市第02選區"
@@ -633,8 +633,8 @@
         "Q49254733"
       ],
       "type": {
-        "lang:zh_TW": "基隆市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Keelung"
+        "lang:zh-tw": "基隆市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
         "lang:zh_TW": "基隆市第03選區"
@@ -657,8 +657,8 @@
         "Q49254733"
       ],
       "type": {
-        "lang:zh_TW": "基隆市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Keelung"
+        "lang:zh-tw": "基隆市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
         "lang:zh_TW": "基隆市第04選區"
@@ -681,8 +681,8 @@
         "Q49254733"
       ],
       "type": {
-        "lang:zh_TW": "基隆市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Keelung"
+        "lang:zh-tw": "基隆市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
         "lang:zh_TW": "基隆市第05選區"
@@ -705,8 +705,8 @@
         "Q49254733"
       ],
       "type": {
-        "lang:zh_TW": "基隆市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Keelung"
+        "lang:zh-tw": "基隆市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
         "lang:zh_TW": "基隆市第06選區"
@@ -729,8 +729,8 @@
         "Q49254733"
       ],
       "type": {
-        "lang:zh_TW": "基隆市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Keelung"
+        "lang:zh-tw": "基隆市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
         "lang:zh_TW": "基隆市第07選區"
@@ -753,8 +753,8 @@
         "Q49254733"
       ],
       "type": {
-        "lang:zh_TW": "基隆市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Keelung"
+        "lang:zh-tw": "基隆市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
         "lang:zh_TW": "基隆市第08選區"
@@ -777,8 +777,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -797,12 +797,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -814,12 +814,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -831,12 +831,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -848,12 +848,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -865,12 +865,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -882,12 +882,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -899,12 +899,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -916,12 +916,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -933,12 +933,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -950,12 +950,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -967,12 +967,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -984,12 +984,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1001,12 +1001,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1018,12 +1018,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1035,12 +1035,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1052,12 +1052,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1069,12 +1069,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1086,12 +1086,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1103,12 +1103,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1119,12 +1119,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1136,12 +1136,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1153,12 +1153,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1170,12 +1170,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1187,12 +1187,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1204,12 +1204,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1220,12 +1220,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1236,12 +1236,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1253,12 +1253,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1270,12 +1270,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1288,12 +1288,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     },
     {
@@ -1305,12 +1305,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254733",
       "role": {
-        "lang:zh_TW": "基隆市議員"
+        "lang:zh-tw": "基隆市議員"
       }
     }
   ]

--- a/legislative/Q11070079/Q49996108/popolo-m17n.json
+++ b/legislative/Q11070079/Q49996108/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "謝典霖"
+        "lang:zh-tw": "謝典霖"
       },
       "id": "Q16260025",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪宗熠"
+        "lang:zh-tw": "洪宗熠"
       },
       "id": "Q19849340",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃玉芬"
+        "lang:zh-tw": "黃玉芬"
       },
       "id": "Q22100343",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉惠娟"
+        "lang:zh-tw": "劉惠娟"
       },
       "id": "Q24836091",
       "identifiers": [
@@ -62,7 +62,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林世賢"
+        "lang:zh-tw": "林世賢"
       },
       "id": "Q30942247",
       "identifiers": [
@@ -77,8 +77,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳淑娟",
-        "lang:en_US": "Wu Shujuan"
+        "lang:zh-tw": "吳淑娟",
+        "lang:en": "Wu Shujuan"
       },
       "id": "Q45593278",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾世勇"
+        "lang:zh-tw": "曾世勇"
       },
       "id": "Q50067136",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林茂明"
+        "lang:zh-tw": "林茂明"
       },
       "id": "Q50067184",
       "identifiers": [
@@ -123,7 +123,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃育寬"
+        "lang:zh-tw": "黃育寬"
       },
       "id": "Q50067223",
       "identifiers": [
@@ -138,7 +138,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顧黃水花"
+        "lang:zh-tw": "顧黃水花"
       },
       "id": "Q50067282",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許原龍"
+        "lang:zh-tw": "許原龍"
       },
       "id": "Q50067372",
       "identifiers": [
@@ -168,7 +168,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "白玉如"
+        "lang:zh-tw": "白玉如"
       },
       "id": "Q50067418",
       "identifiers": [
@@ -183,7 +183,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳蔣秀美"
+        "lang:zh-tw": "陳蔣秀美"
       },
       "id": "Q50067457",
       "identifiers": [
@@ -198,7 +198,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張瀚天"
+        "lang:zh-tw": "張瀚天"
       },
       "id": "Q50067501",
       "identifiers": [
@@ -213,7 +213,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴岸璋"
+        "lang:zh-tw": "賴岸璋"
       },
       "id": "Q50067544",
       "identifiers": [
@@ -228,7 +228,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張東正"
+        "lang:zh-tw": "張東正"
       },
       "id": "Q50067589",
       "identifiers": [
@@ -243,7 +243,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "施性鍾"
+        "lang:zh-tw": "施性鍾"
       },
       "id": "Q50067620",
       "identifiers": [
@@ -258,7 +258,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊竣程"
+        "lang:zh-tw": "楊竣程"
       },
       "id": "Q50067650",
       "identifiers": [
@@ -273,7 +273,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "葉國雄"
+        "lang:zh-tw": "葉國雄"
       },
       "id": "Q50067680",
       "identifiers": [
@@ -288,7 +288,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳秀寳"
+        "lang:zh-tw": "陳秀寳"
       },
       "id": "Q50067722",
       "identifiers": [
@@ -303,7 +303,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林士堅"
+        "lang:zh-tw": "林士堅"
       },
       "id": "Q50067770",
       "identifiers": [
@@ -318,7 +318,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林聖哲"
+        "lang:zh-tw": "林聖哲"
       },
       "id": "Q50067857",
       "identifiers": [
@@ -333,7 +333,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭國賓"
+        "lang:zh-tw": "郭國賓"
       },
       "id": "Q50067906",
       "identifiers": [
@@ -348,7 +348,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "凃淑媚"
+        "lang:zh-tw": "凃淑媚"
       },
       "id": "Q50067949",
       "identifiers": [
@@ -363,7 +363,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蕭文雄"
+        "lang:zh-tw": "蕭文雄"
       },
       "id": "Q50067991",
       "identifiers": [
@@ -378,7 +378,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "尤瑞春"
+        "lang:zh-tw": "尤瑞春"
       },
       "id": "Q50068033",
       "identifiers": [
@@ -393,7 +393,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林宗翰"
+        "lang:zh-tw": "林宗翰"
       },
       "id": "Q50068081",
       "identifiers": [
@@ -408,7 +408,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林庚壬"
+        "lang:zh-tw": "林庚壬"
       },
       "id": "Q50068122",
       "identifiers": [
@@ -423,7 +423,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "柯振杯"
+        "lang:zh-tw": "柯振杯"
       },
       "id": "Q50068167",
       "identifiers": [
@@ -438,7 +438,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴清美"
+        "lang:zh-tw": "賴清美"
       },
       "id": "Q50068215",
       "identifiers": [
@@ -453,7 +453,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "葉麗娟"
+        "lang:zh-tw": "葉麗娟"
       },
       "id": "Q50068303",
       "identifiers": [
@@ -468,7 +468,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曹嘉豪"
+        "lang:zh-tw": "曹嘉豪"
       },
       "id": "Q50068347",
       "identifiers": [
@@ -483,7 +483,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張雪如"
+        "lang:zh-tw": "張雪如"
       },
       "id": "Q50068389",
       "identifiers": [
@@ -498,7 +498,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃正盛"
+        "lang:zh-tw": "黃正盛"
       },
       "id": "Q50068430",
       "identifiers": [
@@ -513,7 +513,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴澤民"
+        "lang:zh-tw": "賴澤民"
       },
       "id": "Q50068481",
       "identifiers": [
@@ -528,7 +528,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "游振雄"
+        "lang:zh-tw": "游振雄"
       },
       "id": "Q50068526",
       "identifiers": [
@@ -543,7 +543,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳秋蓉"
+        "lang:zh-tw": "陳秋蓉"
       },
       "id": "Q50068564",
       "identifiers": [
@@ -558,7 +558,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳重嘉"
+        "lang:zh-tw": "陳重嘉"
       },
       "id": "Q50068605",
       "identifiers": [
@@ -573,7 +573,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張春洋"
+        "lang:zh-tw": "張春洋"
       },
       "id": "Q50068637",
       "identifiers": [
@@ -588,7 +588,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "歐陽蓁珠"
+        "lang:zh-tw": "歐陽蓁珠"
       },
       "id": "Q50068669",
       "identifiers": [
@@ -603,7 +603,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李清木"
+        "lang:zh-tw": "李清木"
       },
       "id": "Q50068716",
       "identifiers": [
@@ -618,7 +618,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張永泉"
+        "lang:zh-tw": "張永泉"
       },
       "id": "Q50068767",
       "identifiers": [
@@ -633,7 +633,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蕭淑芬"
+        "lang:zh-tw": "蕭淑芬"
       },
       "id": "Q50068861",
       "identifiers": [
@@ -648,7 +648,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蕭如意"
+        "lang:zh-tw": "蕭如意"
       },
       "id": "Q50068901",
       "identifiers": [
@@ -663,7 +663,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許書維"
+        "lang:zh-tw": "許書維"
       },
       "id": "Q50068943",
       "identifiers": [
@@ -678,7 +678,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉景滄"
+        "lang:zh-tw": "劉景滄"
       },
       "id": "Q50068990",
       "identifiers": [
@@ -693,7 +693,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "江熊一楓"
+        "lang:zh-tw": "江熊一楓"
       },
       "id": "Q50069034",
       "identifiers": [
@@ -708,7 +708,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉淑芳"
+        "lang:zh-tw": "劉淑芳"
       },
       "id": "Q50069081",
       "identifiers": [
@@ -723,7 +723,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李浩誠"
+        "lang:zh-tw": "李浩誠"
       },
       "id": "Q50069129",
       "identifiers": [
@@ -738,7 +738,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李俊諭"
+        "lang:zh-tw": "李俊諭"
       },
       "id": "Q50069172",
       "identifiers": [
@@ -753,7 +753,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳光輝"
+        "lang:zh-tw": "陳光輝"
       },
       "id": "Q50069254",
       "identifiers": [
@@ -768,7 +768,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳一惇"
+        "lang:zh-tw": "陳一惇"
       },
       "id": "Q50069303",
       "identifiers": [
@@ -783,7 +783,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝彥慧"
+        "lang:zh-tw": "謝彥慧"
       },
       "id": "Q50069345",
       "identifiers": [
@@ -798,7 +798,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳榮妹"
+        "lang:zh-tw": "陳榮妹"
       },
       "id": "Q50069417",
       "identifiers": [
@@ -813,7 +813,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳文漢"
+        "lang:zh-tw": "陳文漢"
       },
       "id": "Q8273054",
       "identifiers": [
@@ -828,8 +828,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃秀芳",
-        "lang:en_US": "Huang Hsiu-fang"
+        "lang:zh-tw": "黃秀芳",
+        "lang:en": "Huang Hsiu-fang"
       },
       "id": "Q8349282",
       "identifiers": [
@@ -846,8 +846,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "彰化縣議會",
-        "lang:en_US": "Changhua County Council"
+        "lang:zh-tw": "彰化縣議會",
+        "lang:en": "Changhua County Council"
       },
       "id": "Q11070079",
       "classification": "branch",
@@ -864,8 +864,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -878,8 +878,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -908,8 +908,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -933,8 +933,8 @@
         "Q49255147"
       ],
       "type": {
-        "lang:zh_TW": "彰化縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Changhua County"
+        "lang:zh-tw": "彰化縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
         "lang:zh_TW": "彰化縣第01選區"
@@ -957,8 +957,8 @@
         "Q49255147"
       ],
       "type": {
-        "lang:zh_TW": "彰化縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Changhua County"
+        "lang:zh-tw": "彰化縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
         "lang:zh_TW": "彰化縣第02選區"
@@ -981,8 +981,8 @@
         "Q49255147"
       ],
       "type": {
-        "lang:zh_TW": "彰化縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Changhua County"
+        "lang:zh-tw": "彰化縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
         "lang:zh_TW": "彰化縣第03選區"
@@ -1005,8 +1005,8 @@
         "Q49255147"
       ],
       "type": {
-        "lang:zh_TW": "彰化縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Changhua County"
+        "lang:zh-tw": "彰化縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
         "lang:zh_TW": "彰化縣第04選區"
@@ -1029,8 +1029,8 @@
         "Q49255147"
       ],
       "type": {
-        "lang:zh_TW": "彰化縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Changhua County"
+        "lang:zh-tw": "彰化縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
         "lang:zh_TW": "彰化縣第05選區"
@@ -1053,8 +1053,8 @@
         "Q49255147"
       ],
       "type": {
-        "lang:zh_TW": "彰化縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Changhua County"
+        "lang:zh-tw": "彰化縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
         "lang:zh_TW": "彰化縣第06選區"
@@ -1077,8 +1077,8 @@
         "Q49255147"
       ],
       "type": {
-        "lang:zh_TW": "彰化縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Changhua County"
+        "lang:zh-tw": "彰化縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
         "lang:zh_TW": "彰化縣第07選區"
@@ -1101,8 +1101,8 @@
         "Q49255147"
       ],
       "type": {
-        "lang:zh_TW": "彰化縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Changhua County"
+        "lang:zh-tw": "彰化縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
         "lang:zh_TW": "彰化縣第08選區"
@@ -1125,8 +1125,8 @@
         "Q49255147"
       ],
       "type": {
-        "lang:zh_TW": "彰化縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Changhua County"
+        "lang:zh-tw": "彰化縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
         "lang:zh_TW": "彰化縣第09選區"
@@ -1149,8 +1149,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -1169,12 +1169,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1187,12 +1187,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1203,12 +1203,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1220,12 +1220,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1237,12 +1237,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1253,12 +1253,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1270,12 +1270,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1286,12 +1286,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1303,12 +1303,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1320,12 +1320,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1337,12 +1337,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1354,12 +1354,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1371,12 +1371,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1387,12 +1387,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1404,12 +1404,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1420,12 +1420,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1438,12 +1438,12 @@
       "end_date": "2015-12-08",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1455,12 +1455,12 @@
       "start_date": "2015-12-08",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1472,12 +1472,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1489,12 +1489,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1506,12 +1506,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1523,12 +1523,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1540,12 +1540,12 @@
       "end_date": "2016-02-04",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1557,12 +1557,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1574,12 +1574,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1591,12 +1591,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1607,12 +1607,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1624,12 +1624,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1641,12 +1641,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1658,12 +1658,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1675,12 +1675,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1692,12 +1692,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1708,12 +1708,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1725,12 +1725,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1742,12 +1742,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1759,12 +1759,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1776,12 +1776,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1792,12 +1792,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1808,12 +1808,12 @@
       "start_date": "2016-04-14",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1825,12 +1825,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1842,12 +1842,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1859,12 +1859,12 @@
       "end_date": "2016-04-14",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1875,12 +1875,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1892,12 +1892,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1909,12 +1909,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1925,12 +1925,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1942,12 +1942,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1959,12 +1959,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1976,12 +1976,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -1993,12 +1993,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -2009,12 +2009,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -2026,12 +2026,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -2043,12 +2043,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -2060,12 +2060,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -2077,12 +2077,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     },
     {
@@ -2095,12 +2095,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255147",
       "role": {
-        "lang:zh_TW": "彰化縣議員"
+        "lang:zh-tw": "彰化縣議員"
       }
     }
   ]

--- a/legislative/Q11081523/Q50167668/popolo-m17n.json
+++ b/legislative/Q11081523/Q50167668/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "李坤城"
+        "lang:zh-tw": "李坤城"
       },
       "id": "Q15935127",
       "identifiers": [
@@ -17,8 +17,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳明義",
-        "lang:en_US": "Chen Mingyi (Taiwan）"
+        "lang:zh-tw": "陳明義",
+        "lang:en": "Chen Mingyi (Taiwan）"
       },
       "id": "Q15955832",
       "identifiers": [
@@ -33,7 +33,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳文治"
+        "lang:zh-tw": "陳文治"
       },
       "id": "Q18384128",
       "identifiers": [
@@ -48,7 +48,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱婷蔚"
+        "lang:zh-tw": "邱婷蔚"
       },
       "id": "Q18663302",
       "identifiers": [
@@ -63,7 +63,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鍾宏仁"
+        "lang:zh-tw": "鍾宏仁"
       },
       "id": "Q18668852",
       "identifiers": [
@@ -78,7 +78,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾煥嘉"
+        "lang:zh-tw": "曾煥嘉"
       },
       "id": "Q19825342",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張晉婷"
+        "lang:zh-tw": "張晉婷"
       },
       "id": "Q19825617",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林裔綺"
+        "lang:zh-tw": "林裔綺"
       },
       "id": "Q19825680",
       "identifiers": [
@@ -123,7 +123,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭宇恩"
+        "lang:zh-tw": "鄭宇恩"
       },
       "id": "Q19825823",
       "identifiers": [
@@ -138,7 +138,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳錦錠"
+        "lang:zh-tw": "陳錦錠"
       },
       "id": "Q19825847",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳世榮"
+        "lang:zh-tw": "陳世榮"
       },
       "id": "Q19825848",
       "identifiers": [
@@ -168,8 +168,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳琪銘",
-        "lang:en_US": "Wu Chi-ming"
+        "lang:zh-tw": "吳琪銘",
+        "lang:en": "Wu Chi-ming"
       },
       "id": "Q19849414",
       "identifiers": [
@@ -184,7 +184,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃林玲玲"
+        "lang:zh-tw": "黃林玲玲"
       },
       "id": "Q21449558",
       "identifiers": [
@@ -199,7 +199,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳幸進"
+        "lang:zh-tw": "陳幸進"
       },
       "id": "Q24833561",
       "identifiers": [
@@ -214,7 +214,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔣根煌"
+        "lang:zh-tw": "蔣根煌"
       },
       "id": "Q24833767",
       "identifiers": [
@@ -229,7 +229,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳儀君"
+        "lang:zh-tw": "陳儀君"
       },
       "id": "Q24836704",
       "identifiers": [
@@ -244,7 +244,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭戴麗香"
+        "lang:zh-tw": "鄭戴麗香"
       },
       "id": "Q28416553",
       "identifiers": [
@@ -259,7 +259,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡葉偉"
+        "lang:zh-tw": "蔡葉偉"
       },
       "id": "Q28416592",
       "identifiers": [
@@ -274,7 +274,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李翁月娥"
+        "lang:zh-tw": "李翁月娥"
       },
       "id": "Q28417334",
       "identifiers": [
@@ -289,7 +289,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林國春"
+        "lang:zh-tw": "林國春"
       },
       "id": "Q30941039",
       "identifiers": [
@@ -304,8 +304,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王建章",
-        "lang:en_US": "Wang Jianzhang"
+        "lang:zh-tw": "王建章",
+        "lang:en": "Wang Jianzhang"
       },
       "id": "Q45529980",
       "identifiers": [
@@ -320,7 +320,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡淑君"
+        "lang:zh-tw": "蔡淑君"
       },
       "id": "Q47546114",
       "identifiers": [
@@ -335,7 +335,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳永福"
+        "lang:zh-tw": "陳永福"
       },
       "id": "Q48897481",
       "identifiers": [
@@ -350,7 +350,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡錦賢"
+        "lang:zh-tw": "蔡錦賢"
       },
       "id": "Q50069459",
       "identifiers": [
@@ -365,7 +365,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴秋媚"
+        "lang:zh-tw": "賴秋媚"
       },
       "id": "Q50069717",
       "identifiers": [
@@ -380,7 +380,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何淑峯"
+        "lang:zh-tw": "何淑峯"
       },
       "id": "Q50069799",
       "identifiers": [
@@ -395,7 +395,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "宋明宗"
+        "lang:zh-tw": "宋明宗"
       },
       "id": "Q50070000",
       "identifiers": [
@@ -410,7 +410,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳科名"
+        "lang:zh-tw": "陳科名"
       },
       "id": "Q50070035",
       "identifiers": [
@@ -425,7 +425,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭金隆"
+        "lang:zh-tw": "鄭金隆"
       },
       "id": "Q50070076",
       "identifiers": [
@@ -440,7 +440,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳啟能"
+        "lang:zh-tw": "陳啟能"
       },
       "id": "Q50070241",
       "identifiers": [
@@ -455,7 +455,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡明堂"
+        "lang:zh-tw": "蔡明堂"
       },
       "id": "Q50070286",
       "identifiers": [
@@ -470,7 +470,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李余典"
+        "lang:zh-tw": "李余典"
       },
       "id": "Q50070394",
       "identifiers": [
@@ -485,7 +485,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃俊哲"
+        "lang:zh-tw": "黃俊哲"
       },
       "id": "Q50070601",
       "identifiers": [
@@ -500,7 +500,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖裕德"
+        "lang:zh-tw": "廖裕德"
       },
       "id": "Q50070668",
       "identifiers": [
@@ -515,7 +515,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周勝考"
+        "lang:zh-tw": "周勝考"
       },
       "id": "Q50070755",
       "identifiers": [
@@ -530,7 +530,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱烽堯"
+        "lang:zh-tw": "邱烽堯"
       },
       "id": "Q50070789",
       "identifiers": [
@@ -545,7 +545,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "游輝宂"
+        "lang:zh-tw": "游輝宂"
       },
       "id": "Q50070833",
       "identifiers": [
@@ -560,7 +560,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅文崇"
+        "lang:zh-tw": "羅文崇"
       },
       "id": "Q50071048",
       "identifiers": [
@@ -575,7 +575,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許昭興"
+        "lang:zh-tw": "許昭興"
       },
       "id": "Q50071088",
       "identifiers": [
@@ -590,7 +590,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "連斐璠"
+        "lang:zh-tw": "連斐璠"
       },
       "id": "Q50071127",
       "identifiers": [
@@ -605,7 +605,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳鴻源"
+        "lang:zh-tw": "陳鴻源"
       },
       "id": "Q50071170",
       "identifiers": [
@@ -620,7 +620,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林銘仁"
+        "lang:zh-tw": "林銘仁"
       },
       "id": "Q50071208",
       "identifiers": [
@@ -635,7 +635,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林金結"
+        "lang:zh-tw": "林金結"
       },
       "id": "Q50071252",
       "identifiers": [
@@ -650,7 +650,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "高敏慧"
+        "lang:zh-tw": "高敏慧"
       },
       "id": "Q50071296",
       "identifiers": [
@@ -665,7 +665,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "彭成龍"
+        "lang:zh-tw": "彭成龍"
       },
       "id": "Q50071342",
       "identifiers": [
@@ -680,7 +680,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇有仁"
+        "lang:zh-tw": "蘇有仁"
       },
       "id": "Q50071567",
       "identifiers": [
@@ -695,7 +695,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉哲彰"
+        "lang:zh-tw": "劉哲彰"
       },
       "id": "Q50071668",
       "identifiers": [
@@ -710,7 +710,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "金中玉"
+        "lang:zh-tw": "金中玉"
       },
       "id": "Q50071710",
       "identifiers": [
@@ -725,7 +725,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖筱清"
+        "lang:zh-tw": "廖筱清"
       },
       "id": "Q50071752",
       "identifiers": [
@@ -740,7 +740,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖正良"
+        "lang:zh-tw": "廖正良"
       },
       "id": "Q50071865",
       "identifiers": [
@@ -755,7 +755,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周雅玲"
+        "lang:zh-tw": "周雅玲"
       },
       "id": "Q50071950",
       "identifiers": [
@@ -770,7 +770,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "白珮茹"
+        "lang:zh-tw": "白珮茹"
       },
       "id": "Q50071992",
       "identifiers": [
@@ -785,7 +785,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "宋雨蓁Nikar‧Falong"
+        "lang:zh-tw": "宋雨蓁Nikar‧Falong"
       },
       "id": "Q50072069",
       "identifiers": [
@@ -800,7 +800,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊春妹"
+        "lang:zh-tw": "楊春妹"
       },
       "id": "Q50072104",
       "identifiers": [
@@ -815,8 +815,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王淑慧",
-        "lang:en_US": "Wang Shu-hui"
+        "lang:zh-tw": "王淑慧",
+        "lang:en": "Wang Shu-hui"
       },
       "id": "Q7967625",
       "identifiers": [
@@ -831,7 +831,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪佳君"
+        "lang:zh-tw": "洪佳君"
       },
       "id": "Q8273543",
       "identifiers": [
@@ -846,7 +846,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃永昌"
+        "lang:zh-tw": "黃永昌"
       },
       "id": "Q8274110",
       "identifiers": [
@@ -861,7 +861,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉美芳"
+        "lang:zh-tw": "劉美芳"
       },
       "id": "Q8274527",
       "identifiers": [
@@ -876,7 +876,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張瑞山"
+        "lang:zh-tw": "張瑞山"
       },
       "id": "Q8347460",
       "identifiers": [
@@ -891,7 +891,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林秀惠"
+        "lang:zh-tw": "林秀惠"
       },
       "id": "Q8349597",
       "identifiers": [
@@ -906,7 +906,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李倩萍"
+        "lang:zh-tw": "李倩萍"
       },
       "id": "Q8349626",
       "identifiers": [
@@ -921,7 +921,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李婉鈺"
+        "lang:zh-tw": "李婉鈺"
       },
       "id": "Q8349628",
       "identifiers": [
@@ -936,8 +936,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "夷將‧拔路兒Icyang‧Parod",
-        "lang:en_US": "Icyang Parod"
+        "lang:zh-tw": "夷將‧拔路兒Icyang‧Parod",
+        "lang:en": "Icyang Parod"
       },
       "id": "Q8350030",
       "identifiers": [
@@ -952,8 +952,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "沈發惠",
-        "lang:en_US": "Shen Fa-hui"
+        "lang:zh-tw": "沈發惠",
+        "lang:en": "Shen Fa-hui"
       },
       "id": "Q8350180",
       "identifiers": [
@@ -968,8 +968,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張宏陸",
-        "lang:en_US": "Chang Hung-lu"
+        "lang:zh-tw": "張宏陸",
+        "lang:en": "Chang Hung-lu"
       },
       "id": "Q8350806",
       "identifiers": [
@@ -984,7 +984,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何博文"
+        "lang:zh-tw": "何博文"
       },
       "id": "Q8350824",
       "identifiers": [
@@ -999,8 +999,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖本煙",
-        "lang:en_US": "Liao Pen-yen"
+        "lang:zh-tw": "廖本煙",
+        "lang:en": "Liao Pen-yen"
       },
       "id": "Q8350893",
       "identifiers": [
@@ -1015,7 +1015,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "江永昌"
+        "lang:zh-tw": "江永昌"
       },
       "id": "Q8350960",
       "identifiers": [
@@ -1032,8 +1032,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "新北市議會",
-        "lang:en_US": "New Taipei City Council"
+        "lang:zh-tw": "新北市議會",
+        "lang:en": "New Taipei City Council"
       },
       "id": "Q11081523",
       "classification": "branch",
@@ -1050,8 +1050,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -1064,8 +1064,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "台灣團結聯盟",
-        "lang:en_US": "Taiwan Solidarity Union"
+        "lang:zh-tw": "台灣團結聯盟",
+        "lang:en": "Taiwan Solidarity Union"
       },
       "id": "Q706834",
       "classification": "party",
@@ -1078,8 +1078,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "無黨團結聯盟",
-        "lang:en_US": "Non-Partisan Solidarity Union"
+        "lang:zh-tw": "無黨團結聯盟",
+        "lang:en": "Non-Partisan Solidarity Union"
       },
       "id": "Q718487",
       "classification": "party",
@@ -1092,8 +1092,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -1122,8 +1122,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -1147,8 +1147,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第01選區"
@@ -1171,8 +1171,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第02選區"
@@ -1195,8 +1195,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第03選區"
@@ -1219,8 +1219,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第04選區"
@@ -1243,8 +1243,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第05選區"
@@ -1267,8 +1267,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第06選區"
@@ -1291,8 +1291,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第07選區"
@@ -1315,8 +1315,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第08選區"
@@ -1339,8 +1339,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第09選區"
@@ -1363,8 +1363,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第10選區"
@@ -1387,8 +1387,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第11選區"
@@ -1411,8 +1411,8 @@
         "Q48976144"
       ],
       "type": {
-        "lang:zh_TW": "新北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of New Taipei City"
+        "lang:zh-tw": "新北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
         "lang:zh_TW": "新北市第12選區"
@@ -1435,8 +1435,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -1455,12 +1455,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1472,12 +1472,12 @@
       "start_date": "2016-04-29",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1489,12 +1489,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1506,12 +1506,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1523,12 +1523,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1540,12 +1540,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1558,12 +1558,12 @@
       "end_date": "2016-04-29",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1575,12 +1575,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1592,12 +1592,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1609,12 +1609,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1625,12 +1625,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1643,12 +1643,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1660,12 +1660,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1677,12 +1677,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1694,12 +1694,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1711,12 +1711,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1728,12 +1728,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1745,12 +1745,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1761,12 +1761,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1778,12 +1778,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1795,12 +1795,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1812,12 +1812,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1829,12 +1829,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1846,12 +1846,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1863,12 +1863,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1880,12 +1880,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1897,12 +1897,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1914,12 +1914,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1931,12 +1931,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1948,12 +1948,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1965,12 +1965,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1982,12 +1982,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -1999,12 +1999,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2016,12 +2016,12 @@
       "end_date": "2016-07-05",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2033,12 +2033,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2050,12 +2050,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2067,12 +2067,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2084,12 +2084,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2101,12 +2101,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2118,12 +2118,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2135,12 +2135,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2152,12 +2152,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2169,12 +2169,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2186,12 +2186,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2203,12 +2203,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2220,12 +2220,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2237,12 +2237,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2254,12 +2254,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2271,12 +2271,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2288,12 +2288,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2305,12 +2305,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2322,12 +2322,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2339,12 +2339,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2356,12 +2356,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2373,12 +2373,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2390,12 +2390,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2407,12 +2407,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2424,12 +2424,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2441,12 +2441,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2458,12 +2458,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2475,12 +2475,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2491,12 +2491,12 @@
       "start_date": "2016-07-05",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2509,12 +2509,12 @@
       "end_date": "2016-05-20",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2526,12 +2526,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2544,12 +2544,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2561,12 +2561,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2578,12 +2578,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     },
     {
@@ -2596,12 +2596,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q48976144",
       "role": {
-        "lang:zh_TW": "新北市議員"
+        "lang:zh-tw": "新北市議員"
       }
     }
   ]

--- a/legislative/Q11084017/Q50179034/popolo-m17n.json
+++ b/legislative/Q11084017/Q50179034/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "施乃如",
-        "lang:en_US": "Shih Nai-ju"
+        "lang:zh-tw": "施乃如",
+        "lang:en": "Shih Nai-ju"
       },
       "id": "Q18653578",
       "identifiers": [
@@ -18,7 +18,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝文進"
+        "lang:zh-tw": "謝文進"
       },
       "id": "Q20062685",
       "identifiers": [
@@ -33,8 +33,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳啓源",
-        "lang:en_US": "Chen Qiyuan"
+        "lang:zh-tw": "陳啓源",
+        "lang:en": "Chen Qiyuan"
       },
       "id": "Q45439632",
       "identifiers": [
@@ -49,7 +49,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳國寶"
+        "lang:zh-tw": "吳國寶"
       },
       "id": "Q48913968",
       "identifiers": [
@@ -64,7 +64,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅文熾"
+        "lang:zh-tw": "羅文熾"
       },
       "id": "Q50072164",
       "identifiers": [
@@ -79,7 +79,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鍾淑英"
+        "lang:zh-tw": "鍾淑英"
       },
       "id": "Q50072196",
       "identifiers": [
@@ -94,7 +94,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾資程"
+        "lang:zh-tw": "曾資程"
       },
       "id": "Q50072259",
       "identifiers": [
@@ -109,7 +109,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "段孝芳"
+        "lang:zh-tw": "段孝芳"
       },
       "id": "Q50072298",
       "identifiers": [
@@ -124,7 +124,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張祖琰"
+        "lang:zh-tw": "張祖琰"
       },
       "id": "Q50072336",
       "identifiers": [
@@ -139,7 +139,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉聲正"
+        "lang:zh-tw": "劉聲正"
       },
       "id": "Q50072425",
       "identifiers": [
@@ -154,7 +154,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李國璋"
+        "lang:zh-tw": "李國璋"
       },
       "id": "Q50072472",
       "identifiers": [
@@ -169,7 +169,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭宏輝"
+        "lang:zh-tw": "鄭宏輝"
       },
       "id": "Q50072514",
       "identifiers": [
@@ -184,7 +184,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "余邦彥"
+        "lang:zh-tw": "余邦彥"
       },
       "id": "Q50072558",
       "identifiers": [
@@ -199,7 +199,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝希誠"
+        "lang:zh-tw": "謝希誠"
       },
       "id": "Q50072592",
       "identifiers": [
@@ -214,7 +214,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許文棟"
+        "lang:zh-tw": "許文棟"
       },
       "id": "Q50072659",
       "identifiers": [
@@ -229,7 +229,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐信芳"
+        "lang:zh-tw": "徐信芳"
       },
       "id": "Q50072690",
       "identifiers": [
@@ -244,7 +244,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許修睿"
+        "lang:zh-tw": "許修睿"
       },
       "id": "Q50072722",
       "identifiers": [
@@ -259,7 +259,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭正宗"
+        "lang:zh-tw": "鄭正宗"
       },
       "id": "Q50072750",
       "identifiers": [
@@ -274,7 +274,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳治雄"
+        "lang:zh-tw": "陳治雄"
       },
       "id": "Q50072785",
       "identifiers": [
@@ -289,7 +289,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蕭志潔"
+        "lang:zh-tw": "蕭志潔"
       },
       "id": "Q50072849",
       "identifiers": [
@@ -304,7 +304,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳清全"
+        "lang:zh-tw": "陳清全"
       },
       "id": "Q50072953",
       "identifiers": [
@@ -319,7 +319,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳秋穀"
+        "lang:zh-tw": "吳秋穀"
       },
       "id": "Q50072976",
       "identifiers": [
@@ -334,7 +334,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃美慧"
+        "lang:zh-tw": "黃美慧"
       },
       "id": "Q50073047",
       "identifiers": [
@@ -349,7 +349,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "孫鍚洲"
+        "lang:zh-tw": "孫鍚洲"
       },
       "id": "Q50073069",
       "identifiers": [
@@ -364,7 +364,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭成光"
+        "lang:zh-tw": "鄭成光"
       },
       "id": "Q50073096",
       "identifiers": [
@@ -379,7 +379,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林盈徹"
+        "lang:zh-tw": "林盈徹"
       },
       "id": "Q50073131",
       "identifiers": [
@@ -394,7 +394,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林耕仁"
+        "lang:zh-tw": "林耕仁"
       },
       "id": "Q50073209",
       "identifiers": [
@@ -409,7 +409,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賀玉燕"
+        "lang:zh-tw": "賀玉燕"
       },
       "id": "Q50073239",
       "identifiers": [
@@ -424,7 +424,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林慈愛"
+        "lang:zh-tw": "林慈愛"
       },
       "id": "Q50073307",
       "identifiers": [
@@ -439,7 +439,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳青山"
+        "lang:zh-tw": "吳青山"
       },
       "id": "Q8277321",
       "identifiers": [
@@ -454,7 +454,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭貴元"
+        "lang:zh-tw": "鄭貴元"
       },
       "id": "Q8349501",
       "identifiers": [
@@ -469,7 +469,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭正鈐"
+        "lang:zh-tw": "鄭正鈐"
       },
       "id": "Q8974428",
       "identifiers": [
@@ -484,7 +484,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顏政德"
+        "lang:zh-tw": "顏政德"
       },
       "id": "Q9076242",
       "identifiers": [
@@ -499,7 +499,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李姸慧"
+        "lang:zh-tw": "李姸慧"
       },
       "id": "Q9197968",
       "identifiers": [
@@ -516,8 +516,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "新竹市議會",
-        "lang:en_US": "Hsinchu City Council"
+        "lang:zh-tw": "新竹市議會",
+        "lang:en": "Hsinchu City Council"
       },
       "id": "Q11084017",
       "classification": "branch",
@@ -534,8 +534,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -548,8 +548,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -578,8 +578,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -603,8 +603,8 @@
         "Q49255439"
       ],
       "type": {
-        "lang:zh_TW": "新竹市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu"
+        "lang:zh-tw": "新竹市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
         "lang:zh_TW": "新竹市第01選區"
@@ -627,8 +627,8 @@
         "Q49255439"
       ],
       "type": {
-        "lang:zh_TW": "新竹市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu"
+        "lang:zh-tw": "新竹市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
         "lang:zh_TW": "新竹市第02選區"
@@ -651,8 +651,8 @@
         "Q49255439"
       ],
       "type": {
-        "lang:zh_TW": "新竹市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu"
+        "lang:zh-tw": "新竹市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
         "lang:zh_TW": "新竹市第03選區"
@@ -675,8 +675,8 @@
         "Q49255439"
       ],
       "type": {
-        "lang:zh_TW": "新竹市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu"
+        "lang:zh-tw": "新竹市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
         "lang:zh_TW": "新竹市第04選區"
@@ -699,8 +699,8 @@
         "Q49255439"
       ],
       "type": {
-        "lang:zh_TW": "新竹市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu"
+        "lang:zh-tw": "新竹市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
         "lang:zh_TW": "新竹市第05選區"
@@ -723,8 +723,8 @@
         "Q49255439"
       ],
       "type": {
-        "lang:zh_TW": "新竹市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu"
+        "lang:zh-tw": "新竹市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
         "lang:zh_TW": "新竹市第06選區"
@@ -747,8 +747,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -767,12 +767,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -783,12 +783,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -799,12 +799,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -815,12 +815,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -831,12 +831,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -848,12 +848,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -865,12 +865,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -882,12 +882,12 @@
       "start_date": "2016-04-26",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -899,12 +899,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -916,12 +916,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -933,12 +933,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -950,12 +950,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -966,12 +966,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -984,12 +984,12 @@
       "end_date": "2016-04-26",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1000,12 +1000,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1017,12 +1017,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1033,12 +1033,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1050,12 +1050,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1067,12 +1067,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1084,12 +1084,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1100,12 +1100,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1117,12 +1117,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1133,12 +1133,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1149,12 +1149,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1166,12 +1166,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1183,12 +1183,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1200,12 +1200,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1217,12 +1217,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1234,12 +1234,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1251,12 +1251,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1268,12 +1268,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1285,12 +1285,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1302,12 +1302,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     },
     {
@@ -1319,12 +1319,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255439",
       "role": {
-        "lang:zh_TW": "新竹市議員"
+        "lang:zh-tw": "新竹市議員"
       }
     }
   ]

--- a/legislative/Q11084065/Q49996265/popolo-m17n.json
+++ b/legislative/Q11084065/Q49996265/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "林光榮"
+        "lang:zh-tw": "林光榮"
       },
       "id": "Q15926084",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "高偉凱"
+        "lang:zh-tw": "高偉凱"
       },
       "id": "Q15941668",
       "identifiers": [
@@ -32,8 +32,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱靖雅",
-        "lang:en_US": "Chiu Ching-ya"
+        "lang:zh-tw": "邱靖雅",
+        "lang:en": "Chiu Ching-ya"
       },
       "id": "Q18119253",
       "identifiers": [
@@ -48,7 +48,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳見賢"
+        "lang:zh-tw": "陳見賢"
       },
       "id": "Q50073367",
       "identifiers": [
@@ -63,7 +63,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊敬賜"
+        "lang:zh-tw": "楊敬賜"
       },
       "id": "Q50073402",
       "identifiers": [
@@ -78,7 +78,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林保光"
+        "lang:zh-tw": "林保光"
       },
       "id": "Q50073446",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳凱榮"
+        "lang:zh-tw": "陳凱榮"
       },
       "id": "Q50073483",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "葉芬英"
+        "lang:zh-tw": "葉芬英"
       },
       "id": "Q50073507",
       "identifiers": [
@@ -123,7 +123,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇明輝"
+        "lang:zh-tw": "蘇明輝"
       },
       "id": "Q50073532",
       "identifiers": [
@@ -138,7 +138,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭美琴"
+        "lang:zh-tw": "鄭美琴"
       },
       "id": "Q50073602",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳菊花"
+        "lang:zh-tw": "吳菊花"
       },
       "id": "Q50073622",
       "identifiers": [
@@ -168,7 +168,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "甄克堅"
+        "lang:zh-tw": "甄克堅"
       },
       "id": "Q50073651",
       "identifiers": [
@@ -183,7 +183,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃永傳"
+        "lang:zh-tw": "黃永傳"
       },
       "id": "Q50073675",
       "identifiers": [
@@ -198,7 +198,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳淑君"
+        "lang:zh-tw": "吳淑君"
       },
       "id": "Q50073709",
       "identifiers": [
@@ -213,7 +213,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張春鳳"
+        "lang:zh-tw": "張春鳳"
       },
       "id": "Q50073741",
       "identifiers": [
@@ -228,7 +228,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳栢維"
+        "lang:zh-tw": "陳栢維"
       },
       "id": "Q50073771",
       "identifiers": [
@@ -243,7 +243,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅春蘭"
+        "lang:zh-tw": "羅春蘭"
       },
       "id": "Q50073807",
       "identifiers": [
@@ -258,7 +258,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭清漢"
+        "lang:zh-tw": "鄭清漢"
       },
       "id": "Q50073845",
       "identifiers": [
@@ -273,7 +273,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張鎮榮"
+        "lang:zh-tw": "張鎮榮"
       },
       "id": "Q50073884",
       "identifiers": [
@@ -288,7 +288,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳傳地"
+        "lang:zh-tw": "吳傳地"
       },
       "id": "Q50073922",
       "identifiers": [
@@ -303,7 +303,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉良彬"
+        "lang:zh-tw": "劉良彬"
       },
       "id": "Q50073967",
       "identifiers": [
@@ -318,7 +318,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "嚴永秋"
+        "lang:zh-tw": "嚴永秋"
       },
       "id": "Q50074008",
       "identifiers": [
@@ -333,7 +333,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴江海"
+        "lang:zh-tw": "賴江海"
       },
       "id": "Q50074046",
       "identifiers": [
@@ -348,7 +348,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "范曰富"
+        "lang:zh-tw": "范曰富"
       },
       "id": "Q50074083",
       "identifiers": [
@@ -363,7 +363,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張志弘"
+        "lang:zh-tw": "張志弘"
       },
       "id": "Q50074120",
       "identifiers": [
@@ -378,7 +378,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林政良"
+        "lang:zh-tw": "林政良"
       },
       "id": "Q50074165",
       "identifiers": [
@@ -393,7 +393,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅吉祥"
+        "lang:zh-tw": "羅吉祥"
       },
       "id": "Q50074211",
       "identifiers": [
@@ -408,7 +408,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林昭錡"
+        "lang:zh-tw": "林昭錡"
       },
       "id": "Q50074259",
       "identifiers": [
@@ -423,7 +423,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳勝松"
+        "lang:zh-tw": "吳勝松"
       },
       "id": "Q50074311",
       "identifiers": [
@@ -438,7 +438,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "彭余美玲"
+        "lang:zh-tw": "彭余美玲"
       },
       "id": "Q50074361",
       "identifiers": [
@@ -453,7 +453,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭遠彰"
+        "lang:zh-tw": "郭遠彰"
       },
       "id": "Q50074442",
       "identifiers": [
@@ -468,7 +468,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周江杰"
+        "lang:zh-tw": "周江杰"
       },
       "id": "Q50074486",
       "identifiers": [
@@ -483,7 +483,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林思銘"
+        "lang:zh-tw": "林思銘"
       },
       "id": "Q50074526",
       "identifiers": [
@@ -498,7 +498,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱振瑋"
+        "lang:zh-tw": "邱振瑋"
       },
       "id": "Q50074571",
       "identifiers": [
@@ -513,7 +513,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳正順"
+        "lang:zh-tw": "陳正順"
       },
       "id": "Q50074607",
       "identifiers": [
@@ -528,7 +528,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "范坤松"
+        "lang:zh-tw": "范坤松"
       },
       "id": "Q50074691",
       "identifiers": [
@@ -543,7 +543,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "趙一先"
+        "lang:zh-tw": "趙一先"
       },
       "id": "Q50074731",
       "identifiers": [
@@ -558,7 +558,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林為洲"
+        "lang:zh-tw": "林為洲"
       },
       "id": "Q8351569",
       "identifiers": [
@@ -575,8 +575,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "新竹縣議會",
-        "lang:en_US": "Hsinchu County Council"
+        "lang:zh-tw": "新竹縣議會",
+        "lang:en": "Hsinchu County Council"
       },
       "id": "Q11084065",
       "classification": "branch",
@@ -593,8 +593,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民國黨",
-        "lang:en_US": "Minkuotang"
+        "lang:zh-tw": "民國黨",
+        "lang:en": "Minkuotang"
       },
       "id": "Q19684454",
       "classification": "party",
@@ -607,8 +607,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "綠黨",
-        "lang:en_US": "Green Party"
+        "lang:zh-tw": "綠黨",
+        "lang:en": "Green Party"
       },
       "id": "Q213451",
       "classification": "party",
@@ -621,8 +621,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -635,7 +635,7 @@
     },
     {
       "name": {
-        "lang:en_US": "Labor Party"
+        "lang:en": "Labor Party"
       },
       "id": "Q835664",
       "classification": "party",
@@ -648,8 +648,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -678,8 +678,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第01選區"
@@ -702,8 +702,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第02選區"
@@ -726,8 +726,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第03選區"
@@ -750,8 +750,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第04選區"
@@ -774,8 +774,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第05選區"
@@ -798,8 +798,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第06選區"
@@ -822,8 +822,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第07選區"
@@ -846,8 +846,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第08選區"
@@ -870,8 +870,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第09選區"
@@ -894,8 +894,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第10選區"
@@ -918,8 +918,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第11選區"
@@ -942,8 +942,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第12選區"
@@ -966,8 +966,8 @@
         "Q49255593"
       ],
       "type": {
-        "lang:zh_TW": "新竹縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hsinchu County"
+        "lang:zh-tw": "新竹縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
         "lang:zh_TW": "新竹縣第13選區"
@@ -990,8 +990,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -1015,8 +1015,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -1035,12 +1035,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1053,12 +1053,12 @@
       "end_date": "2017-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1070,12 +1070,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1087,12 +1087,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1104,12 +1104,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1121,12 +1121,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1138,12 +1138,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1155,12 +1155,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1172,12 +1172,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1188,12 +1188,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1206,12 +1206,12 @@
       "end_date": "2016-01-27",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1223,12 +1223,12 @@
       "start_date": "2016-01-06",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1241,12 +1241,12 @@
       "end_date": "2016-01-06",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1258,12 +1258,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1274,12 +1274,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1291,12 +1291,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1308,12 +1308,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1325,12 +1325,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1342,12 +1342,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1359,12 +1359,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1376,12 +1376,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1392,12 +1392,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1409,12 +1409,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1426,12 +1426,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1443,12 +1443,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1460,12 +1460,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1477,12 +1477,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1494,12 +1494,12 @@
       "start_date": "2016-03-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1512,12 +1512,12 @@
       "end_date": "2016-03-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1529,12 +1529,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1546,12 +1546,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1564,12 +1564,12 @@
       "end_date": "2017-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1581,12 +1581,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1597,12 +1597,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1614,12 +1614,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1631,12 +1631,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1648,12 +1648,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     },
     {
@@ -1666,12 +1666,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255593",
       "role": {
-        "lang:zh_TW": "新竹縣議員"
+        "lang:zh-tw": "新竹縣議員"
       }
     }
   ]

--- a/legislative/Q11112210/Q49996297/popolo-m17n.json
+++ b/legislative/Q11112210/Q49996297/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "黃景熙"
+        "lang:zh-tw": "黃景熙"
       },
       "id": "Q11176440",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳瑛"
+        "lang:zh-tw": "陳瑛"
       },
       "id": "Q15903406",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳志謀"
+        "lang:zh-tw": "陳志謀"
       },
       "id": "Q16908001",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃敬平"
+        "lang:zh-tw": "黃敬平"
       },
       "id": "Q16908359",
       "identifiers": [
@@ -62,7 +62,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王浩宇"
+        "lang:zh-tw": "王浩宇"
       },
       "id": "Q18654613",
       "identifiers": [
@@ -77,7 +77,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳賴素美"
+        "lang:zh-tw": "陳賴素美"
       },
       "id": "Q19825208",
       "identifiers": [
@@ -92,7 +92,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "彭俊豪"
+        "lang:zh-tw": "彭俊豪"
       },
       "id": "Q19825622",
       "identifiers": [
@@ -107,7 +107,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張肇良"
+        "lang:zh-tw": "張肇良"
       },
       "id": "Q21040218",
       "identifiers": [
@@ -122,7 +122,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳宗憲"
+        "lang:zh-tw": "吳宗憲"
       },
       "id": "Q21055059",
       "identifiers": [
@@ -137,8 +137,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "趙正宇",
-        "lang:en_US": "Chao Cheng-yu"
+        "lang:zh-tw": "趙正宇",
+        "lang:en": "Chao Cheng-yu"
       },
       "id": "Q22100240",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱奕勝"
+        "lang:zh-tw": "邱奕勝"
       },
       "id": "Q22100595",
       "identifiers": [
@@ -168,7 +168,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林政賢"
+        "lang:zh-tw": "林政賢"
       },
       "id": "Q28418573",
       "identifiers": [
@@ -183,7 +183,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "魯明哲"
+        "lang:zh-tw": "魯明哲"
       },
       "id": "Q30941045",
       "identifiers": [
@@ -198,7 +198,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張火爐"
+        "lang:zh-tw": "張火爐"
       },
       "id": "Q30942957",
       "identifiers": [
@@ -213,8 +213,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡永芳",
-        "lang:en_US": "Cai Yongfang"
+        "lang:zh-tw": "蔡永芳",
+        "lang:en": "Cai Yongfang"
       },
       "id": "Q45540571",
       "identifiers": [
@@ -229,7 +229,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "范綱祥"
+        "lang:zh-tw": "范綱祥"
       },
       "id": "Q47669448",
       "identifiers": [
@@ -244,7 +244,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳美梅"
+        "lang:zh-tw": "陳美梅"
       },
       "id": "Q50074772",
       "identifiers": [
@@ -259,7 +259,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃婉如"
+        "lang:zh-tw": "黃婉如"
       },
       "id": "Q50074821",
       "identifiers": [
@@ -274,7 +274,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱素芬"
+        "lang:zh-tw": "邱素芬"
       },
       "id": "Q50074907",
       "identifiers": [
@@ -289,7 +289,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇家明"
+        "lang:zh-tw": "蘇家明"
       },
       "id": "Q50074948",
       "identifiers": [
@@ -304,7 +304,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "萬美玲"
+        "lang:zh-tw": "萬美玲"
       },
       "id": "Q50075031",
       "identifiers": [
@@ -319,7 +319,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李光達"
+        "lang:zh-tw": "李光達"
       },
       "id": "Q50075072",
       "identifiers": [
@@ -334,7 +334,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李曉鐘"
+        "lang:zh-tw": "李曉鐘"
       },
       "id": "Q50075123",
       "identifiers": [
@@ -349,7 +349,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "詹江村"
+        "lang:zh-tw": "詹江村"
       },
       "id": "Q50075173",
       "identifiers": [
@@ -364,7 +364,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林俐玲"
+        "lang:zh-tw": "林俐玲"
       },
       "id": "Q50075281",
       "identifiers": [
@@ -379,7 +379,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李雲強"
+        "lang:zh-tw": "李雲強"
       },
       "id": "Q50075333",
       "identifiers": [
@@ -394,7 +394,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "呂林小鳳"
+        "lang:zh-tw": "呂林小鳳"
       },
       "id": "Q50075491",
       "identifiers": [
@@ -409,7 +409,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉茂群"
+        "lang:zh-tw": "劉茂群"
       },
       "id": "Q50075552",
       "identifiers": [
@@ -424,7 +424,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "呂淑真"
+        "lang:zh-tw": "呂淑真"
       },
       "id": "Q50075596",
       "identifiers": [
@@ -439,7 +439,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳麗莉"
+        "lang:zh-tw": "陳麗莉"
       },
       "id": "Q50075697",
       "identifiers": [
@@ -454,7 +454,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許清順"
+        "lang:zh-tw": "許清順"
       },
       "id": "Q50075732",
       "identifiers": [
@@ -469,7 +469,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭麗華"
+        "lang:zh-tw": "郭麗華"
       },
       "id": "Q50075774",
       "identifiers": [
@@ -484,7 +484,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉勝全"
+        "lang:zh-tw": "劉勝全"
       },
       "id": "Q50075831",
       "identifiers": [
@@ -499,7 +499,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐其萬"
+        "lang:zh-tw": "徐其萬"
       },
       "id": "Q50075870",
       "identifiers": [
@@ -514,7 +514,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "游吾和"
+        "lang:zh-tw": "游吾和"
       },
       "id": "Q50075907",
       "identifiers": [
@@ -529,7 +529,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊朝偉"
+        "lang:zh-tw": "楊朝偉"
       },
       "id": "Q50075948",
       "identifiers": [
@@ -544,7 +544,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳治文"
+        "lang:zh-tw": "陳治文"
       },
       "id": "Q50075980",
       "identifiers": [
@@ -559,7 +559,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李柏坊"
+        "lang:zh-tw": "李柏坊"
       },
       "id": "Q50076036",
       "identifiers": [
@@ -574,7 +574,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張運炳"
+        "lang:zh-tw": "張運炳"
       },
       "id": "Q50076083",
       "identifiers": [
@@ -589,7 +589,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "梁為超"
+        "lang:zh-tw": "梁為超"
       },
       "id": "Q50076161",
       "identifiers": [
@@ -604,7 +604,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉曾玉春"
+        "lang:zh-tw": "劉曾玉春"
       },
       "id": "Q50076238",
       "identifiers": [
@@ -619,7 +619,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "袁明星"
+        "lang:zh-tw": "袁明星"
       },
       "id": "Q50076279",
       "identifiers": [
@@ -634,7 +634,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃傅淑香"
+        "lang:zh-tw": "黃傅淑香"
       },
       "id": "Q50076380",
       "identifiers": [
@@ -649,7 +649,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "葉明月"
+        "lang:zh-tw": "葉明月"
       },
       "id": "Q50076473",
       "identifiers": [
@@ -664,7 +664,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "舒翠玲"
+        "lang:zh-tw": "舒翠玲"
       },
       "id": "Q50076548",
       "identifiers": [
@@ -679,7 +679,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "莊玉輝"
+        "lang:zh-tw": "莊玉輝"
       },
       "id": "Q50076658",
       "identifiers": [
@@ -694,7 +694,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊家俍"
+        "lang:zh-tw": "楊家俍"
       },
       "id": "Q50076708",
       "identifiers": [
@@ -709,7 +709,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉仁照"
+        "lang:zh-tw": "劉仁照"
       },
       "id": "Q50076751",
       "identifiers": [
@@ -724,7 +724,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝彰文"
+        "lang:zh-tw": "謝彰文"
       },
       "id": "Q50076792",
       "identifiers": [
@@ -739,7 +739,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李家興"
+        "lang:zh-tw": "李家興"
       },
       "id": "Q50076935",
       "identifiers": [
@@ -754,7 +754,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "閻中傑"
+        "lang:zh-tw": "閻中傑"
       },
       "id": "Q50077028",
       "identifiers": [
@@ -769,7 +769,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐玉樹"
+        "lang:zh-tw": "徐玉樹"
       },
       "id": "Q50077062",
       "identifiers": [
@@ -784,7 +784,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱佳亮"
+        "lang:zh-tw": "邱佳亮"
       },
       "id": "Q50077099",
       "identifiers": [
@@ -799,7 +799,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "歐炳辰"
+        "lang:zh-tw": "歐炳辰"
       },
       "id": "Q50077225",
       "identifiers": [
@@ -814,7 +814,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊進福"
+        "lang:zh-tw": "楊進福"
       },
       "id": "Q50077272",
       "identifiers": [
@@ -829,7 +829,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳春芳"
+        "lang:zh-tw": "吳春芳"
       },
       "id": "Q50077317",
       "identifiers": [
@@ -844,7 +844,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林志強"
+        "lang:zh-tw": "林志強"
       },
       "id": "Q50077353",
       "identifiers": [
@@ -859,7 +859,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇志強"
+        "lang:zh-tw": "蘇志強"
       },
       "id": "Q50077410",
       "identifiers": [
@@ -874,7 +874,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周玉琴"
+        "lang:zh-tw": "周玉琴"
       },
       "id": "Q50184527",
       "identifiers": [
@@ -889,7 +889,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林正峰"
+        "lang:zh-tw": "林正峰"
       },
       "id": "Q8275249",
       "identifiers": [
@@ -904,8 +904,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭榮宗",
-        "lang:en_US": "Kuo June-tsung"
+        "lang:zh-tw": "郭榮宗",
+        "lang:en": "Kuo June-tsung"
       },
       "id": "Q8357076",
       "identifiers": [
@@ -922,8 +922,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "桃園市議會",
-        "lang:en_US": "Taoyuan County Council"
+        "lang:zh-tw": "桃園市議會",
+        "lang:en": "Taoyuan County Council"
       },
       "id": "Q11112210",
       "classification": "branch",
@@ -940,8 +940,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "綠黨",
-        "lang:en_US": "Green Party"
+        "lang:zh-tw": "綠黨",
+        "lang:en": "Green Party"
       },
       "id": "Q213451",
       "classification": "party",
@@ -954,8 +954,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -968,8 +968,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "無黨團結聯盟",
-        "lang:en_US": "Non-Partisan Solidarity Union"
+        "lang:zh-tw": "無黨團結聯盟",
+        "lang:en": "Non-Partisan Solidarity Union"
       },
       "id": "Q718487",
       "classification": "party",
@@ -982,8 +982,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -1012,8 +1012,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -1037,8 +1037,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第01選區"
@@ -1061,8 +1061,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第02選區"
@@ -1085,8 +1085,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第03選區"
@@ -1109,8 +1109,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第04選區"
@@ -1133,8 +1133,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第05選區"
@@ -1157,8 +1157,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第06選區"
@@ -1181,8 +1181,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第07選區"
@@ -1205,8 +1205,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第08選區"
@@ -1229,8 +1229,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第09選區"
@@ -1253,8 +1253,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第10選區"
@@ -1277,8 +1277,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第11選區"
@@ -1301,8 +1301,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第12選區"
@@ -1325,8 +1325,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第13選區"
@@ -1349,8 +1349,8 @@
         "Q49255748"
       ],
       "type": {
-        "lang:zh_TW": "桃園市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taoyuan City"
+        "lang:zh-tw": "桃園市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
         "lang:zh_TW": "桃園市第14選區"
@@ -1373,8 +1373,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -1393,12 +1393,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1410,12 +1410,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1427,12 +1427,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1444,12 +1444,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1461,12 +1461,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1479,12 +1479,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1496,12 +1496,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1513,12 +1513,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1529,12 +1529,12 @@
       "start_date": "2015-08-24",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1546,12 +1546,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1563,12 +1563,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1580,12 +1580,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1597,12 +1597,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1614,12 +1614,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1631,12 +1631,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1648,12 +1648,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1665,12 +1665,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1682,12 +1682,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1699,12 +1699,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1716,12 +1716,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1733,12 +1733,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1750,12 +1750,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1767,12 +1767,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1784,12 +1784,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1801,12 +1801,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1818,12 +1818,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1835,12 +1835,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1852,12 +1852,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1869,12 +1869,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1886,12 +1886,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1903,12 +1903,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1920,12 +1920,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1937,12 +1937,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1954,12 +1954,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1971,12 +1971,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -1988,12 +1988,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2005,12 +2005,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2022,12 +2022,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2039,12 +2039,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2056,12 +2056,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2073,12 +2073,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2091,12 +2091,12 @@
       "end_date": "2016-03-28",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2108,12 +2108,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2125,12 +2125,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2142,12 +2142,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2159,12 +2159,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2176,12 +2176,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2193,12 +2193,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2210,12 +2210,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2227,12 +2227,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2244,12 +2244,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2261,12 +2261,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2278,12 +2278,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2295,12 +2295,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2312,12 +2312,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2329,12 +2329,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2346,12 +2346,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2363,12 +2363,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2380,12 +2380,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2397,12 +2397,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     },
     {
@@ -2415,12 +2415,12 @@
       "end_date": "2015-08-24",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255748",
       "role": {
-        "lang:zh_TW": "桃園市議員"
+        "lang:zh-tw": "桃園市議員"
       }
     }
   ]

--- a/legislative/Q15899378/Q49996566/popolo-m17n.json
+++ b/legislative/Q15899378/Q49996566/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "李天生",
-        "lang:en_US": "Li Tian Sheng"
+        "lang:zh-tw": "李天生",
+        "lang:en": "Li Tian Sheng"
       },
       "id": "Q10317826",
       "identifiers": [
@@ -18,8 +18,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張玉嬿",
-        "lang:en_US": "Crystal Chang"
+        "lang:zh-tw": "張玉嬿",
+        "lang:en": "Crystal Chang"
       },
       "id": "Q11068800",
       "identifiers": [
@@ -34,7 +34,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊永昌"
+        "lang:zh-tw": "楊永昌"
       },
       "id": "Q11118616",
       "identifiers": [
@@ -49,7 +49,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊典忠"
+        "lang:zh-tw": "楊典忠"
       },
       "id": "Q15934897",
       "identifiers": [
@@ -64,8 +64,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李麗華 (政治人物)",
-        "lang:en_US": "Lee Li-hua (politician)"
+        "lang:zh-tw": "李麗華 (政治人物)",
+        "lang:en": "Lee Li-hua (politician)"
       },
       "id": "Q15936919",
       "identifiers": [
@@ -80,7 +80,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何文海"
+        "lang:zh-tw": "何文海"
       },
       "id": "Q15939492",
       "identifiers": [
@@ -95,7 +95,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "段緯宇"
+        "lang:zh-tw": "段緯宇"
       },
       "id": "Q15954545",
       "identifiers": [
@@ -110,7 +110,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳敏濟"
+        "lang:zh-tw": "吳敏濟"
       },
       "id": "Q15955721",
       "identifiers": [
@@ -125,7 +125,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳清龍"
+        "lang:zh-tw": "陳清龍"
       },
       "id": "Q16926972",
       "identifiers": [
@@ -140,7 +140,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉淑蘭"
+        "lang:zh-tw": "劉淑蘭"
       },
       "id": "Q16928851",
       "identifiers": [
@@ -155,7 +155,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾朝榮"
+        "lang:zh-tw": "曾朝榮"
       },
       "id": "Q16928998",
       "identifiers": [
@@ -170,7 +170,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林士昌"
+        "lang:zh-tw": "林士昌"
       },
       "id": "Q16929054",
       "identifiers": [
@@ -185,7 +185,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林汝洲"
+        "lang:zh-tw": "林汝洲"
       },
       "id": "Q17026553",
       "identifiers": [
@@ -200,8 +200,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃國書",
-        "lang:en_US": "Huang Kuo-shu"
+        "lang:zh-tw": "黃國書",
+        "lang:en": "Huang Kuo-shu"
       },
       "id": "Q19058548",
       "identifiers": [
@@ -216,7 +216,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴義鍠"
+        "lang:zh-tw": "賴義鍠"
       },
       "id": "Q21449519",
       "identifiers": [
@@ -231,7 +231,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "朱元宏"
+        "lang:zh-tw": "朱元宏"
       },
       "id": "Q22773529",
       "identifiers": [
@@ -246,7 +246,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張雅旻"
+        "lang:zh-tw": "張雅旻"
       },
       "id": "Q28408857",
       "identifiers": [
@@ -261,7 +261,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃馨慧"
+        "lang:zh-tw": "黃馨慧"
       },
       "id": "Q28409830",
       "identifiers": [
@@ -276,7 +276,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱素貞"
+        "lang:zh-tw": "邱素貞"
       },
       "id": "Q30948834",
       "identifiers": [
@@ -294,8 +294,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李中",
-        "lang:en_US": "Li Zhong"
+        "lang:zh-tw": "李中",
+        "lang:en": "Li Zhong"
       },
       "id": "Q45558342",
       "identifiers": [
@@ -310,7 +310,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林素真"
+        "lang:zh-tw": "林素真"
       },
       "id": "Q50078508",
       "identifiers": [
@@ -325,7 +325,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顏莉敏"
+        "lang:zh-tw": "顏莉敏"
       },
       "id": "Q50078674",
       "identifiers": [
@@ -340,7 +340,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "尤碧鈴"
+        "lang:zh-tw": "尤碧鈴"
       },
       "id": "Q50078736",
       "identifiers": [
@@ -355,7 +355,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王立任"
+        "lang:zh-tw": "王立任"
       },
       "id": "Q50078784",
       "identifiers": [
@@ -370,7 +370,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張清照"
+        "lang:zh-tw": "張清照"
       },
       "id": "Q50078886",
       "identifiers": [
@@ -385,7 +385,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃錫嘉"
+        "lang:zh-tw": "黃錫嘉"
       },
       "id": "Q50079033",
       "identifiers": [
@@ -400,7 +400,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張瀞分"
+        "lang:zh-tw": "張瀞分"
       },
       "id": "Q50079213",
       "identifiers": [
@@ -415,7 +415,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳本添"
+        "lang:zh-tw": "陳本添"
       },
       "id": "Q50079277",
       "identifiers": [
@@ -430,7 +430,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張立傑"
+        "lang:zh-tw": "張立傑"
       },
       "id": "Q50079313",
       "identifiers": [
@@ -445,7 +445,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉士州"
+        "lang:zh-tw": "劉士州"
       },
       "id": "Q50079698",
       "identifiers": [
@@ -460,7 +460,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "朱暖英"
+        "lang:zh-tw": "朱暖英"
       },
       "id": "Q50079786",
       "identifiers": [
@@ -475,7 +475,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張耀中"
+        "lang:zh-tw": "張耀中"
       },
       "id": "Q50079849",
       "identifiers": [
@@ -490,7 +490,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳成添"
+        "lang:zh-tw": "陳成添"
       },
       "id": "Q50079974",
       "identifiers": [
@@ -505,7 +505,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴順仁"
+        "lang:zh-tw": "賴順仁"
       },
       "id": "Q50080118",
       "identifiers": [
@@ -520,7 +520,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "沈佑蓮"
+        "lang:zh-tw": "沈佑蓮"
       },
       "id": "Q50080190",
       "identifiers": [
@@ -535,7 +535,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "范淞育"
+        "lang:zh-tw": "范淞育"
       },
       "id": "Q50080323",
       "identifiers": [
@@ -550,7 +550,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳政顯"
+        "lang:zh-tw": "陳政顯"
       },
       "id": "Q50080452",
       "identifiers": [
@@ -565,7 +565,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "江肇國"
+        "lang:zh-tw": "江肇國"
       },
       "id": "Q50080540",
       "identifiers": [
@@ -580,7 +580,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭功進"
+        "lang:zh-tw": "鄭功進"
       },
       "id": "Q50080872",
       "identifiers": [
@@ -595,7 +595,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何明杰"
+        "lang:zh-tw": "何明杰"
       },
       "id": "Q50080953",
       "identifiers": [
@@ -610,7 +610,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林碧秀"
+        "lang:zh-tw": "林碧秀"
       },
       "id": "Q50081110",
       "identifiers": [
@@ -625,7 +625,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張滄沂"
+        "lang:zh-tw": "張滄沂"
       },
       "id": "Q50081158",
       "identifiers": [
@@ -640,7 +640,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇柏興"
+        "lang:zh-tw": "蘇柏興"
       },
       "id": "Q50081302",
       "identifiers": [
@@ -655,7 +655,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張芬郁"
+        "lang:zh-tw": "張芬郁"
       },
       "id": "Q50081349",
       "identifiers": [
@@ -670,7 +670,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇慶雲"
+        "lang:zh-tw": "蘇慶雲"
       },
       "id": "Q50081402",
       "identifiers": [
@@ -685,7 +685,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡成圭"
+        "lang:zh-tw": "蔡成圭"
       },
       "id": "Q50081444",
       "identifiers": [
@@ -700,7 +700,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪金福"
+        "lang:zh-tw": "洪金福"
       },
       "id": "Q50081502",
       "identifiers": [
@@ -715,7 +715,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林榮進"
+        "lang:zh-tw": "林榮進"
       },
       "id": "Q50081624",
       "identifiers": [
@@ -730,7 +730,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蕭隆澤"
+        "lang:zh-tw": "蕭隆澤"
       },
       "id": "Q8272785",
       "identifiers": [
@@ -745,7 +745,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳顯森"
+        "lang:zh-tw": "吳顯森"
       },
       "id": "Q8276905",
       "identifiers": [
@@ -760,7 +760,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張宏年"
+        "lang:zh-tw": "張宏年"
       },
       "id": "Q8279229",
       "identifiers": [
@@ -775,7 +775,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳瓊華"
+        "lang:zh-tw": "吳瓊華"
       },
       "id": "Q8279422",
       "identifiers": [
@@ -790,7 +790,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張廖乃綸"
+        "lang:zh-tw": "張廖乃綸"
       },
       "id": "Q8279446",
       "identifiers": [
@@ -805,7 +805,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李榮鴻"
+        "lang:zh-tw": "李榮鴻"
       },
       "id": "Q8279489",
       "identifiers": [
@@ -820,7 +820,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅永珍"
+        "lang:zh-tw": "羅永珍"
       },
       "id": "Q8279720",
       "identifiers": [
@@ -835,7 +835,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴朝國"
+        "lang:zh-tw": "賴朝國"
       },
       "id": "Q8279796",
       "identifiers": [
@@ -850,7 +850,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊正中"
+        "lang:zh-tw": "楊正中"
       },
       "id": "Q8280409",
       "identifiers": [
@@ -865,7 +865,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡雅玲"
+        "lang:zh-tw": "蔡雅玲"
       },
       "id": "Q8347142",
       "identifiers": [
@@ -880,8 +880,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張廖萬堅",
-        "lang:en_US": "Chang Liao Wan-chien"
+        "lang:zh-tw": "張廖萬堅",
+        "lang:en": "Chang Liao Wan-chien"
       },
       "id": "Q8347319",
       "identifiers": [
@@ -896,7 +896,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳世凱"
+        "lang:zh-tw": "陳世凱"
       },
       "id": "Q8347798",
       "identifiers": [
@@ -911,7 +911,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何敏誠"
+        "lang:zh-tw": "何敏誠"
       },
       "id": "Q8348511",
       "identifiers": [
@@ -926,7 +926,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝志忠"
+        "lang:zh-tw": "謝志忠"
       },
       "id": "Q8348569",
       "identifiers": [
@@ -941,7 +941,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴佳微"
+        "lang:zh-tw": "賴佳微"
       },
       "id": "Q8349616",
       "identifiers": [
@@ -956,8 +956,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝明源",
-        "lang:en_US": "Hsieh Ming-yuan"
+        "lang:zh-tw": "謝明源",
+        "lang:en": "Hsieh Ming-yuan"
       },
       "id": "Q8350236",
       "identifiers": [
@@ -972,7 +972,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "翁美春"
+        "lang:zh-tw": "翁美春"
       },
       "id": "Q8350409",
       "identifiers": [
@@ -987,7 +987,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳淑華"
+        "lang:zh-tw": "陳淑華"
       },
       "id": "Q8351160",
       "identifiers": [
@@ -1004,8 +1004,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "臺中市議會",
-        "lang:en_US": "Taichung City Council"
+        "lang:zh-tw": "臺中市議會",
+        "lang:en": "Taichung City Council"
       },
       "id": "Q15899378",
       "classification": "branch",
@@ -1022,8 +1022,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "親民黨",
-        "lang:en_US": "People First Party"
+        "lang:zh-tw": "親民黨",
+        "lang:en": "People First Party"
       },
       "id": "Q1442482",
       "classification": "party",
@@ -1036,8 +1036,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -1050,8 +1050,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -1080,8 +1080,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -1105,8 +1105,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第01選區"
@@ -1129,8 +1129,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第02選區"
@@ -1153,8 +1153,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第03選區"
@@ -1177,8 +1177,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第04選區"
@@ -1201,8 +1201,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第05選區"
@@ -1225,8 +1225,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第06選區"
@@ -1249,8 +1249,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第07選區"
@@ -1273,8 +1273,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第08選區"
@@ -1297,8 +1297,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第09選區"
@@ -1321,8 +1321,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第10選區"
@@ -1345,8 +1345,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第11選區"
@@ -1369,8 +1369,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第12選區"
@@ -1393,8 +1393,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第13選區"
@@ -1417,8 +1417,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第14選區"
@@ -1441,8 +1441,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第15選區"
@@ -1465,8 +1465,8 @@
         "Q10493791"
       ],
       "type": {
-        "lang:zh_TW": "臺中市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taichung"
+        "lang:zh-tw": "臺中市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
         "lang:zh_TW": "臺中市第16選區"
@@ -1489,8 +1489,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -1509,12 +1509,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1526,12 +1526,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1544,12 +1544,12 @@
       "end_date": "2016-02-22",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1561,12 +1561,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1578,12 +1578,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1595,12 +1595,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1612,12 +1612,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1629,12 +1629,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1645,12 +1645,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1662,12 +1662,12 @@
       "start_date": "2016-07-05",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1679,12 +1679,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1696,12 +1696,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1714,12 +1714,12 @@
       "end_date": "2016-07-05",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1732,12 +1732,12 @@
       "end_date": "2015-02-16",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1748,12 +1748,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1765,12 +1765,12 @@
       "start_date": "2016-01-12",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1782,12 +1782,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1799,12 +1799,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1816,12 +1816,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1833,12 +1833,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1851,12 +1851,12 @@
       "end_date": "2017-02-21",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1868,12 +1868,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1884,12 +1884,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1901,12 +1901,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1918,12 +1918,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1935,12 +1935,12 @@
       "end_date": "2015-09-18",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1952,12 +1952,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1969,12 +1969,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -1985,12 +1985,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2002,12 +2002,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2019,12 +2019,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2036,12 +2036,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2053,12 +2053,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2070,12 +2070,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2087,12 +2087,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2104,12 +2104,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2121,12 +2121,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2138,12 +2138,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2155,12 +2155,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2172,12 +2172,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2189,12 +2189,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2205,12 +2205,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2222,12 +2222,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2239,12 +2239,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2256,12 +2256,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2273,12 +2273,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2290,12 +2290,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2308,12 +2308,12 @@
       "end_date": "2016-01-12",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2325,12 +2325,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2342,12 +2342,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2359,12 +2359,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2376,12 +2376,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2393,12 +2393,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2410,12 +2410,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2427,12 +2427,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2444,12 +2444,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2461,12 +2461,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2478,12 +2478,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2496,12 +2496,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2513,12 +2513,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2530,12 +2530,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2547,12 +2547,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2564,12 +2564,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2581,12 +2581,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2598,12 +2598,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     },
     {
@@ -2615,12 +2615,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q10493791",
       "role": {
-        "lang:zh_TW": "臺中市議員"
+        "lang:zh-tw": "臺中市議員"
       }
     }
   ]

--- a/legislative/Q15903185/Q49996052/popolo-m17n.json
+++ b/legislative/Q15903185/Q49996052/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "李香蘭",
-        "lang:en_US": "Yoshiko Yamaguchi"
+        "lang:zh-tw": "李香蘭",
+        "lang:en": "Yoshiko Yamaguchi"
       },
       "id": "Q253862",
       "identifiers": [
@@ -18,8 +18,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許天賜",
-        "lang:en_US": "Xu Tianci"
+        "lang:zh-tw": "許天賜",
+        "lang:en": "Xu Tianci"
       },
       "id": "Q45503552",
       "identifiers": [
@@ -34,8 +34,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林明順",
-        "lang:en_US": "Lin Mingshun"
+        "lang:zh-tw": "林明順",
+        "lang:en": "Lin Mingshun"
       },
       "id": "Q45724760",
       "identifiers": [
@@ -50,7 +50,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉育豪"
+        "lang:zh-tw": "劉育豪"
       },
       "id": "Q50064819",
       "identifiers": [
@@ -65,7 +65,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鍾明輝"
+        "lang:zh-tw": "鍾明輝"
       },
       "id": "Q50064850",
       "identifiers": [
@@ -80,7 +80,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃國安"
+        "lang:zh-tw": "黃國安"
       },
       "id": "Q50064919",
       "identifiers": [
@@ -95,7 +95,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇義峰"
+        "lang:zh-tw": "蘇義峰"
       },
       "id": "Q50065001",
       "identifiers": [
@@ -110,7 +110,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳美瓊"
+        "lang:zh-tw": "陳美瓊"
       },
       "id": "Q50065047",
       "identifiers": [
@@ -125,7 +125,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張金文"
+        "lang:zh-tw": "張金文"
       },
       "id": "Q50065086",
       "identifiers": [
@@ -140,7 +140,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔣家煌"
+        "lang:zh-tw": "蔣家煌"
       },
       "id": "Q50065117",
       "identifiers": [
@@ -155,7 +155,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "唐玉琴"
+        "lang:zh-tw": "唐玉琴"
       },
       "id": "Q50065152",
       "identifiers": [
@@ -170,7 +170,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔣月惠"
+        "lang:zh-tw": "蔣月惠"
       },
       "id": "Q50065187",
       "identifiers": [
@@ -185,7 +185,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張平原"
+        "lang:zh-tw": "張平原"
       },
       "id": "Q50065222",
       "identifiers": [
@@ -200,7 +200,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "江維屏"
+        "lang:zh-tw": "江維屏"
       },
       "id": "Q50065256",
       "identifiers": [
@@ -215,7 +215,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳明達"
+        "lang:zh-tw": "陳明達"
       },
       "id": "Q50065295",
       "identifiers": [
@@ -230,7 +230,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "盧文瑞"
+        "lang:zh-tw": "盧文瑞"
       },
       "id": "Q50065336",
       "identifiers": [
@@ -245,7 +245,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭雙銓"
+        "lang:zh-tw": "鄭雙銓"
       },
       "id": "Q50065365",
       "identifiers": [
@@ -260,7 +260,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳芳琍"
+        "lang:zh-tw": "陳芳琍"
       },
       "id": "Q50065400",
       "identifiers": [
@@ -275,7 +275,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何春美"
+        "lang:zh-tw": "何春美"
       },
       "id": "Q50065428",
       "identifiers": [
@@ -290,7 +290,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "尤慶賀"
+        "lang:zh-tw": "尤慶賀"
       },
       "id": "Q50065469",
       "identifiers": [
@@ -305,7 +305,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳亮慶"
+        "lang:zh-tw": "吳亮慶"
       },
       "id": "Q50065532",
       "identifiers": [
@@ -320,7 +320,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "宋麗華"
+        "lang:zh-tw": "宋麗華"
       },
       "id": "Q50065572",
       "identifiers": [
@@ -335,7 +335,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許馨勻"
+        "lang:zh-tw": "許馨勻"
       },
       "id": "Q50065612",
       "identifiers": [
@@ -350,7 +350,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林郁虹"
+        "lang:zh-tw": "林郁虹"
       },
       "id": "Q50065670",
       "identifiers": [
@@ -365,7 +365,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃建溢"
+        "lang:zh-tw": "黃建溢"
       },
       "id": "Q50065713",
       "identifiers": [
@@ -380,7 +380,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "潘長成"
+        "lang:zh-tw": "潘長成"
       },
       "id": "Q50065765",
       "identifiers": [
@@ -395,7 +395,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "潘淑真"
+        "lang:zh-tw": "潘淑真"
       },
       "id": "Q50065811",
       "identifiers": [
@@ -410,7 +410,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾福金"
+        "lang:zh-tw": "曾福金"
       },
       "id": "Q50065893",
       "identifiers": [
@@ -425,7 +425,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王志豐"
+        "lang:zh-tw": "王志豐"
       },
       "id": "Q50065933",
       "identifiers": [
@@ -440,7 +440,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐榮耀"
+        "lang:zh-tw": "徐榮耀"
       },
       "id": "Q50065971",
       "identifiers": [
@@ -455,7 +455,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉淼松"
+        "lang:zh-tw": "劉淼松"
       },
       "id": "Q50066017",
       "identifiers": [
@@ -470,7 +470,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何輝能"
+        "lang:zh-tw": "何輝能"
       },
       "id": "Q50066066",
       "identifiers": [
@@ -485,7 +485,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林蔡鳳梅"
+        "lang:zh-tw": "林蔡鳳梅"
       },
       "id": "Q50066119",
       "identifiers": [
@@ -500,7 +500,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許展維"
+        "lang:zh-tw": "許展維"
       },
       "id": "Q50066158",
       "identifiers": [
@@ -515,7 +515,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭再添"
+        "lang:zh-tw": "郭再添"
       },
       "id": "Q50066208",
       "identifiers": [
@@ -530,7 +530,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭寶川"
+        "lang:zh-tw": "鄭寶川"
       },
       "id": "Q50066243",
       "identifiers": [
@@ -545,7 +545,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周典論"
+        "lang:zh-tw": "周典論"
       },
       "id": "Q50066275",
       "identifiers": [
@@ -560,7 +560,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉水復"
+        "lang:zh-tw": "劉水復"
       },
       "id": "Q50066345",
       "identifiers": [
@@ -575,7 +575,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周碧雲"
+        "lang:zh-tw": "周碧雲"
       },
       "id": "Q50066378",
       "identifiers": [
@@ -590,7 +590,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林玉花"
+        "lang:zh-tw": "林玉花"
       },
       "id": "Q50066419",
       "identifiers": [
@@ -605,7 +605,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅平道"
+        "lang:zh-tw": "羅平道"
       },
       "id": "Q50066458",
       "identifiers": [
@@ -620,7 +620,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王啟敏"
+        "lang:zh-tw": "王啟敏"
       },
       "id": "Q50066519",
       "identifiers": [
@@ -635,7 +635,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張榮志"
+        "lang:zh-tw": "張榮志"
       },
       "id": "Q50066562",
       "identifiers": [
@@ -650,7 +650,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳文弘"
+        "lang:zh-tw": "陳文弘"
       },
       "id": "Q50066628",
       "identifiers": [
@@ -665,7 +665,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪慈綪"
+        "lang:zh-tw": "洪慈綪"
       },
       "id": "Q50066659",
       "identifiers": [
@@ -680,7 +680,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "潘裕隆"
+        "lang:zh-tw": "潘裕隆"
       },
       "id": "Q50066693",
       "identifiers": [
@@ -695,7 +695,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "歸曉惠"
+        "lang:zh-tw": "歸曉惠"
       },
       "id": "Q50066737",
       "identifiers": [
@@ -710,7 +710,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "車牧勒薩以‧拉勒格安Cemelesailjaljegan"
+        "lang:zh-tw": "車牧勒薩以‧拉勒格安Cemelesailjaljegan"
       },
       "id": "Q50066785",
       "identifiers": [
@@ -725,7 +725,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陸月嬌"
+        "lang:zh-tw": "陸月嬌"
       },
       "id": "Q50066793",
       "identifiers": [
@@ -740,7 +740,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "潘政治"
+        "lang:zh-tw": "潘政治"
       },
       "id": "Q50066832",
       "identifiers": [
@@ -755,7 +755,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "潘正義"
+        "lang:zh-tw": "潘正義"
       },
       "id": "Q50066868",
       "identifiers": [
@@ -770,7 +770,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳昭忠"
+        "lang:zh-tw": "陳昭忠"
       },
       "id": "Q50066898",
       "identifiers": [
@@ -785,7 +785,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林輝雄"
+        "lang:zh-tw": "林輝雄"
       },
       "id": "Q50066928",
       "identifiers": [
@@ -800,7 +800,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李冀香"
+        "lang:zh-tw": "李冀香"
       },
       "id": "Q50066984",
       "identifiers": [
@@ -815,7 +815,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顏金成"
+        "lang:zh-tw": "顏金成"
       },
       "id": "Q50067053",
       "identifiers": [
@@ -830,8 +830,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李志偉",
-        "lang:en_US": "Eric Li"
+        "lang:zh-tw": "李志偉",
+        "lang:en": "Eric Li"
       },
       "id": "Q5354771",
       "identifiers": [
@@ -846,7 +846,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李世斌"
+        "lang:zh-tw": "李世斌"
       },
       "id": "Q8349699",
       "identifiers": [
@@ -863,8 +863,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "屏東縣議會",
-        "lang:en_US": "Pingtung County Council"
+        "lang:zh-tw": "屏東縣議會",
+        "lang:en": "Pingtung County Council"
       },
       "id": "Q15903185",
       "classification": "branch",
@@ -881,8 +881,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -895,8 +895,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "台灣團結聯盟",
-        "lang:en_US": "Taiwan Solidarity Union"
+        "lang:zh-tw": "台灣團結聯盟",
+        "lang:en": "Taiwan Solidarity Union"
       },
       "id": "Q706834",
       "classification": "party",
@@ -909,8 +909,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -939,8 +939,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -964,8 +964,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第01選區"
@@ -988,8 +988,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第02選區"
@@ -1012,8 +1012,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第03選區"
@@ -1036,8 +1036,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第04選區"
@@ -1060,8 +1060,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第05選區"
@@ -1084,8 +1084,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第06選區"
@@ -1108,8 +1108,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第07選區"
@@ -1132,8 +1132,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第08選區"
@@ -1156,8 +1156,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第09選區"
@@ -1180,8 +1180,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第10選區"
@@ -1204,8 +1204,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第11選區"
@@ -1228,8 +1228,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第12選區"
@@ -1252,8 +1252,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第13選區"
@@ -1276,8 +1276,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第14選區"
@@ -1300,8 +1300,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第15選區"
@@ -1324,8 +1324,8 @@
         "Q49255006"
       ],
       "type": {
-        "lang:zh_TW": "屏東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Pingtung County"
+        "lang:zh-tw": "屏東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
         "lang:zh_TW": "屏東縣第16選區"
@@ -1348,8 +1348,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -1368,12 +1368,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1385,12 +1385,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1401,12 +1401,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1418,12 +1418,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1435,12 +1435,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1452,12 +1452,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1469,12 +1469,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1486,12 +1486,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1502,12 +1502,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1518,12 +1518,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1535,12 +1535,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1551,12 +1551,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1567,12 +1567,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1584,12 +1584,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1601,12 +1601,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1617,12 +1617,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1634,12 +1634,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1652,12 +1652,12 @@
       "end_date": "2016-01-11",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1669,12 +1669,12 @@
       "start_date": "2016-01-11",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1685,12 +1685,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1702,12 +1702,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1719,12 +1719,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1736,12 +1736,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1753,12 +1753,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1770,12 +1770,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1787,12 +1787,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1804,12 +1804,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1821,12 +1821,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1838,12 +1838,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1855,12 +1855,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1872,12 +1872,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1889,12 +1889,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1905,12 +1905,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1922,12 +1922,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1938,12 +1938,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1954,12 +1954,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1970,12 +1970,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -1986,12 +1986,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2003,12 +2003,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2020,12 +2020,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2037,12 +2037,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2054,12 +2054,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2071,12 +2071,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2088,12 +2088,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2104,12 +2104,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2121,12 +2121,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2138,12 +2138,12 @@
       "end_date": "2016-04-09",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2154,12 +2154,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2170,12 +2170,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2187,12 +2187,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2203,12 +2203,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2221,12 +2221,12 @@
       "end_date": "2016-05-24",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2237,12 +2237,12 @@
       "start_date": "2016-05-24",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2254,12 +2254,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2271,12 +2271,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2288,12 +2288,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     },
     {
@@ -2305,12 +2305,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255006",
       "role": {
-        "lang:zh_TW": "屏東縣議員"
+        "lang:zh-tw": "屏東縣議員"
       }
     }
   ]

--- a/legislative/Q15904162/Q49996626/popolo-m17n.json
+++ b/legislative/Q15904162/Q49996626/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "林寶珠"
+        "lang:zh-tw": "林寶珠"
       },
       "id": "Q10346874",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張志宇"
+        "lang:zh-tw": "張志宇"
       },
       "id": "Q18234084",
       "identifiers": [
@@ -32,8 +32,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "呂明亮",
-        "lang:en_US": "Lv Mingliang"
+        "lang:zh-tw": "呂明亮",
+        "lang:en": "Lv Mingliang"
       },
       "id": "Q45439850",
       "identifiers": [
@@ -48,7 +48,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "詹運喜"
+        "lang:zh-tw": "詹運喜"
       },
       "id": "Q50086785",
       "identifiers": [
@@ -63,7 +63,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "湯維岳"
+        "lang:zh-tw": "湯維岳"
       },
       "id": "Q50086810",
       "identifiers": [
@@ -78,7 +78,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱鎮軍"
+        "lang:zh-tw": "邱鎮軍"
       },
       "id": "Q50086854",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐集明"
+        "lang:zh-tw": "徐集明"
       },
       "id": "Q50086894",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝文禓"
+        "lang:zh-tw": "謝文禓"
       },
       "id": "Q50086929",
       "identifiers": [
@@ -123,7 +123,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "禹耀東"
+        "lang:zh-tw": "禹耀東"
       },
       "id": "Q50086958",
       "identifiers": [
@@ -138,7 +138,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "胡忠勇"
+        "lang:zh-tw": "胡忠勇"
       },
       "id": "Q50087000",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭碧玉"
+        "lang:zh-tw": "鄭碧玉"
       },
       "id": "Q50087038",
       "identifiers": [
@@ -168,7 +168,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許櫻萍"
+        "lang:zh-tw": "許櫻萍"
       },
       "id": "Q50087080",
       "identifiers": [
@@ -183,7 +183,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "孫素娥"
+        "lang:zh-tw": "孫素娥"
       },
       "id": "Q50087225",
       "identifiers": [
@@ -198,7 +198,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張家靜"
+        "lang:zh-tw": "張家靜"
       },
       "id": "Q50087271",
       "identifiers": [
@@ -213,7 +213,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅貴星"
+        "lang:zh-tw": "羅貴星"
       },
       "id": "Q50087311",
       "identifiers": [
@@ -228,7 +228,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黎旭欽"
+        "lang:zh-tw": "黎旭欽"
       },
       "id": "Q50087342",
       "identifiers": [
@@ -243,7 +243,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "韓茂賢"
+        "lang:zh-tw": "韓茂賢"
       },
       "id": "Q50087384",
       "identifiers": [
@@ -258,7 +258,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉寶鈴"
+        "lang:zh-tw": "劉寶鈴"
       },
       "id": "Q50087471",
       "identifiers": [
@@ -273,7 +273,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉秋東"
+        "lang:zh-tw": "劉秋東"
       },
       "id": "Q50087510",
       "identifiers": [
@@ -288,7 +288,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周玉滿"
+        "lang:zh-tw": "周玉滿"
       },
       "id": "Q50087556",
       "identifiers": [
@@ -303,7 +303,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李聰祥"
+        "lang:zh-tw": "李聰祥"
       },
       "id": "Q50087599",
       "identifiers": [
@@ -318,7 +318,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱紹俊"
+        "lang:zh-tw": "邱紹俊"
       },
       "id": "Q50087637",
       "identifiers": [
@@ -333,7 +333,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃聲全"
+        "lang:zh-tw": "黃聲全"
       },
       "id": "Q50087680",
       "identifiers": [
@@ -348,7 +348,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳碧華"
+        "lang:zh-tw": "陳碧華"
       },
       "id": "Q50087717",
       "identifiers": [
@@ -363,7 +363,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭秋風"
+        "lang:zh-tw": "鄭秋風"
       },
       "id": "Q50087758",
       "identifiers": [
@@ -378,7 +378,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳明朝"
+        "lang:zh-tw": "陳明朝"
       },
       "id": "Q50087809",
       "identifiers": [
@@ -393,7 +393,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖英利"
+        "lang:zh-tw": "廖英利"
       },
       "id": "Q50087854",
       "identifiers": [
@@ -408,7 +408,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝芳紋"
+        "lang:zh-tw": "謝芳紋"
       },
       "id": "Q50087887",
       "identifiers": [
@@ -423,7 +423,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝端容"
+        "lang:zh-tw": "謝端容"
       },
       "id": "Q50087977",
       "identifiers": [
@@ -438,7 +438,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李文斌"
+        "lang:zh-tw": "李文斌"
       },
       "id": "Q50088014",
       "identifiers": [
@@ -453,7 +453,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅雪珠"
+        "lang:zh-tw": "羅雪珠"
       },
       "id": "Q50088057",
       "identifiers": [
@@ -468,7 +468,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "游忠鈿"
+        "lang:zh-tw": "游忠鈿"
       },
       "id": "Q50088091",
       "identifiers": [
@@ -483,7 +483,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳永賢"
+        "lang:zh-tw": "陳永賢"
       },
       "id": "Q50088131",
       "identifiers": [
@@ -498,7 +498,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳光軒"
+        "lang:zh-tw": "陳光軒"
       },
       "id": "Q50088170",
       "identifiers": [
@@ -513,7 +513,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳漢清"
+        "lang:zh-tw": "陳漢清"
       },
       "id": "Q50088210",
       "identifiers": [
@@ -528,7 +528,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鍾福貴"
+        "lang:zh-tw": "鍾福貴"
       },
       "id": "Q50088243",
       "identifiers": [
@@ -543,7 +543,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱秋琴"
+        "lang:zh-tw": "邱秋琴"
       },
       "id": "Q50088276",
       "identifiers": [
@@ -558,7 +558,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鍾東錦"
+        "lang:zh-tw": "鍾東錦"
       },
       "id": "Q50088349",
       "identifiers": [
@@ -573,7 +573,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐欽鴻"
+        "lang:zh-tw": "徐欽鴻"
       },
       "id": "Q50088383",
       "identifiers": [
@@ -588,7 +588,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳春暖"
+        "lang:zh-tw": "陳春暖"
       },
       "id": "Q50088423",
       "identifiers": [
@@ -603,7 +603,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊恭林"
+        "lang:zh-tw": "楊恭林"
       },
       "id": "Q50088465",
       "identifiers": [
@@ -618,7 +618,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "潘秋榮"
+        "lang:zh-tw": "潘秋榮"
       },
       "id": "Q50088503",
       "identifiers": [
@@ -633,7 +633,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃月娥"
+        "lang:zh-tw": "黃月娥"
       },
       "id": "Q50088530",
       "identifiers": [
@@ -650,8 +650,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "苗栗縣議會",
-        "lang:en_US": "Miaoli County Council"
+        "lang:zh-tw": "苗栗縣議會",
+        "lang:en": "Miaoli County Council"
       },
       "id": "Q15904162",
       "classification": "branch",
@@ -668,8 +668,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -682,8 +682,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -712,8 +712,8 @@
         "Q49257021"
       ],
       "type": {
-        "lang:zh_TW": "苗栗縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Miaoli County"
+        "lang:zh-tw": "苗栗縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
         "lang:zh_TW": "苗栗縣第01選區"
@@ -736,8 +736,8 @@
         "Q49257021"
       ],
       "type": {
-        "lang:zh_TW": "苗栗縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Miaoli County"
+        "lang:zh-tw": "苗栗縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
         "lang:zh_TW": "苗栗縣第02選區"
@@ -760,8 +760,8 @@
         "Q49257021"
       ],
       "type": {
-        "lang:zh_TW": "苗栗縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Miaoli County"
+        "lang:zh-tw": "苗栗縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
         "lang:zh_TW": "苗栗縣第03選區"
@@ -784,8 +784,8 @@
         "Q49257021"
       ],
       "type": {
-        "lang:zh_TW": "苗栗縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Miaoli County"
+        "lang:zh-tw": "苗栗縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
         "lang:zh_TW": "苗栗縣第04選區"
@@ -808,8 +808,8 @@
         "Q49257021"
       ],
       "type": {
-        "lang:zh_TW": "苗栗縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Miaoli County"
+        "lang:zh-tw": "苗栗縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
         "lang:zh_TW": "苗栗縣第05選區"
@@ -832,8 +832,8 @@
         "Q49257021"
       ],
       "type": {
-        "lang:zh_TW": "苗栗縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Miaoli County"
+        "lang:zh-tw": "苗栗縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
         "lang:zh_TW": "苗栗縣第06選區"
@@ -856,8 +856,8 @@
         "Q49257021"
       ],
       "type": {
-        "lang:zh_TW": "苗栗縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Miaoli County"
+        "lang:zh-tw": "苗栗縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
         "lang:zh_TW": "苗栗縣第07選區"
@@ -880,8 +880,8 @@
         "Q49257021"
       ],
       "type": {
-        "lang:zh_TW": "苗栗縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Miaoli County"
+        "lang:zh-tw": "苗栗縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
         "lang:zh_TW": "苗栗縣第08選區"
@@ -904,8 +904,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -929,8 +929,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -949,12 +949,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -967,12 +967,12 @@
       "end_date": "2016-03-15",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -984,12 +984,12 @@
       "end_date": "2016-03-15",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1001,12 +1001,12 @@
       "start_date": "2016-03-15",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1017,12 +1017,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1033,12 +1033,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1050,12 +1050,12 @@
       "start_date": "2016-03-15",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1066,12 +1066,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1083,12 +1083,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1100,12 +1100,12 @@
       "start_date": "2016-03-15",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1117,12 +1117,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1135,12 +1135,12 @@
       "end_date": "2016-03-15",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1152,12 +1152,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1170,12 +1170,12 @@
       "end_date": "2015-09-16",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1187,12 +1187,12 @@
       "start_date": "2015-09-16",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1204,12 +1204,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1221,12 +1221,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1237,12 +1237,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1254,12 +1254,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1270,12 +1270,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1287,12 +1287,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1303,12 +1303,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1319,12 +1319,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1336,12 +1336,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1353,12 +1353,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1370,12 +1370,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1387,12 +1387,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1404,12 +1404,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1420,12 +1420,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1437,12 +1437,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1453,12 +1453,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1470,12 +1470,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1487,12 +1487,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1504,12 +1504,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1522,12 +1522,12 @@
       "end_date": "2015-06-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1539,12 +1539,12 @@
       "start_date": "2015-06-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1555,12 +1555,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1571,12 +1571,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1587,12 +1587,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1604,12 +1604,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1620,12 +1620,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1636,12 +1636,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     },
     {
@@ -1653,12 +1653,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257021",
       "role": {
-        "lang:zh_TW": "苗栗縣議員"
+        "lang:zh-tw": "苗栗縣議員"
       }
     }
   ]

--- a/legislative/Q15908339/Q50179059/popolo-m17n.json
+++ b/legislative/Q15908339/Q50179059/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "黃瑞華"
+        "lang:zh-tw": "黃瑞華"
       },
       "id": "Q15945432",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "饒慶鈴"
+        "lang:zh-tw": "饒慶鈴"
       },
       "id": "Q16260582",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪宗楷"
+        "lang:zh-tw": "洪宗楷"
       },
       "id": "Q19825700",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林琮翰"
+        "lang:zh-tw": "林琮翰"
       },
       "id": "Q20063564",
       "identifiers": [
@@ -62,8 +62,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃秋生",
-        "lang:en_US": "Anthony Wong"
+        "lang:zh-tw": "黃秋生",
+        "lang:en": "Anthony Wong"
       },
       "id": "Q381561",
       "identifiers": [
@@ -78,7 +78,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王飛龍"
+        "lang:zh-tw": "王飛龍"
       },
       "id": "Q50084312",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林參天"
+        "lang:zh-tw": "林參天"
       },
       "id": "Q50084321",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李建智"
+        "lang:zh-tw": "李建智"
       },
       "id": "Q50084355",
       "identifiers": [
@@ -123,7 +123,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳景槐"
+        "lang:zh-tw": "吳景槐"
       },
       "id": "Q50084389",
       "identifiers": [
@@ -138,7 +138,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "田石雄"
+        "lang:zh-tw": "田石雄"
       },
       "id": "Q50084504",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳志峰"
+        "lang:zh-tw": "陳志峰"
       },
       "id": "Q50084575",
       "identifiers": [
@@ -168,7 +168,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳秀華"
+        "lang:zh-tw": "吳秀華"
       },
       "id": "Q50084612",
       "identifiers": [
@@ -183,7 +183,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周達三"
+        "lang:zh-tw": "周達三"
       },
       "id": "Q50084648",
       "identifiers": [
@@ -198,7 +198,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張卓然"
+        "lang:zh-tw": "張卓然"
       },
       "id": "Q50084678",
       "identifiers": [
@@ -213,7 +213,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許進榮"
+        "lang:zh-tw": "許進榮"
       },
       "id": "Q50084710",
       "identifiers": [
@@ -228,7 +228,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林東滿"
+        "lang:zh-tw": "林東滿"
       },
       "id": "Q50084746",
       "identifiers": [
@@ -243,7 +243,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "翁麗吟"
+        "lang:zh-tw": "翁麗吟"
       },
       "id": "Q50084854",
       "identifiers": [
@@ -258,7 +258,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝賢裕"
+        "lang:zh-tw": "謝賢裕"
       },
       "id": "Q50084898",
       "identifiers": [
@@ -273,7 +273,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林秀信"
+        "lang:zh-tw": "林秀信"
       },
       "id": "Q50084981",
       "identifiers": [
@@ -288,7 +288,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王清堅"
+        "lang:zh-tw": "王清堅"
       },
       "id": "Q50085029",
       "identifiers": [
@@ -303,7 +303,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "方賢仁"
+        "lang:zh-tw": "方賢仁"
       },
       "id": "Q50085061",
       "identifiers": [
@@ -318,7 +318,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "江堅壽"
+        "lang:zh-tw": "江堅壽"
       },
       "id": "Q50085125",
       "identifiers": [
@@ -333,7 +333,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "尤忠正"
+        "lang:zh-tw": "尤忠正"
       },
       "id": "Q50085159",
       "identifiers": [
@@ -348,7 +348,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張萬生"
+        "lang:zh-tw": "張萬生"
       },
       "id": "Q50085191",
       "identifiers": [
@@ -363,7 +363,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉純歌"
+        "lang:zh-tw": "劉純歌"
       },
       "id": "Q50085233",
       "identifiers": [
@@ -378,7 +378,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "高美珠"
+        "lang:zh-tw": "高美珠"
       },
       "id": "Q50085276",
       "identifiers": [
@@ -393,7 +393,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "胡秋金"
+        "lang:zh-tw": "胡秋金"
       },
       "id": "Q50085316",
       "identifiers": [
@@ -408,7 +408,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張全馨嵐"
+        "lang:zh-tw": "張全馨嵐"
       },
       "id": "Q50085349",
       "identifiers": [
@@ -423,7 +423,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張順成"
+        "lang:zh-tw": "張順成"
       },
       "id": "Q50085358",
       "identifiers": [
@@ -438,7 +438,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "章正輝"
+        "lang:zh-tw": "章正輝"
       },
       "id": "Q50085389",
       "identifiers": [
@@ -453,7 +453,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃天德"
+        "lang:zh-tw": "黃天德"
       },
       "id": "Q50085468",
       "identifiers": [
@@ -468,7 +468,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡玉玲"
+        "lang:zh-tw": "蔡玉玲"
       },
       "id": "Q50369028",
       "identifiers": [
@@ -483,7 +483,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳宏宗"
+        "lang:zh-tw": "陳宏宗"
       },
       "id": "Q9367492",
       "identifiers": [
@@ -500,8 +500,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "臺東縣議會",
-        "lang:en_US": "Taitung County Council"
+        "lang:zh-tw": "臺東縣議會",
+        "lang:en": "Taitung County Council"
       },
       "id": "Q15908339",
       "classification": "branch",
@@ -518,8 +518,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -532,8 +532,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -562,8 +562,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -587,8 +587,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第01選區"
@@ -611,8 +611,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第02選區"
@@ -635,8 +635,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第03選區"
@@ -659,8 +659,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第04選區"
@@ -683,8 +683,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第05選區"
@@ -707,8 +707,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第06選區"
@@ -731,8 +731,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第07選區"
@@ -755,8 +755,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第08選區"
@@ -779,8 +779,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第09選區"
@@ -803,8 +803,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第10選區"
@@ -827,8 +827,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第11選區"
@@ -851,8 +851,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第12選區"
@@ -875,8 +875,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第13選區"
@@ -899,8 +899,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第14選區"
@@ -923,8 +923,8 @@
         "Q49256666"
       ],
       "type": {
-        "lang:zh_TW": "臺東縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taitung County"
+        "lang:zh-tw": "臺東縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
         "lang:zh_TW": "臺東縣第15選區"
@@ -947,8 +947,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -967,12 +967,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -984,12 +984,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1001,12 +1001,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1018,12 +1018,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1035,12 +1035,12 @@
       "end_date": "2015-03-04",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1051,12 +1051,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1067,12 +1067,12 @@
       "start_date": "2015-03-04",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1083,12 +1083,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1100,12 +1100,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1117,12 +1117,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1134,12 +1134,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1151,12 +1151,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1168,12 +1168,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1185,12 +1185,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1202,12 +1202,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1218,12 +1218,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1235,12 +1235,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1252,12 +1252,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1269,12 +1269,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1286,12 +1286,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1304,12 +1304,12 @@
       "end_date": "2015-03-04",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1321,12 +1321,12 @@
       "start_date": "2015-03-04",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1338,12 +1338,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1355,12 +1355,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1372,12 +1372,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1389,12 +1389,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1406,12 +1406,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1423,12 +1423,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1439,12 +1439,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1456,12 +1456,12 @@
       "end_date": "2015-11-27",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1473,12 +1473,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1490,12 +1490,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1507,12 +1507,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     },
     {
@@ -1524,12 +1524,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256666",
       "role": {
-        "lang:zh_TW": "臺東縣議員"
+        "lang:zh-tw": "臺東縣議員"
       }
     }
   ]

--- a/legislative/Q15908941/Q49996733/popolo-m17n.json
+++ b/legislative/Q15908941/Q49996733/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "陳茂源"
+        "lang:zh-tw": "陳茂源"
       },
       "id": "Q10565633",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡秋敏"
+        "lang:zh-tw": "蔡秋敏"
       },
       "id": "Q17059691",
       "identifiers": [
@@ -32,8 +32,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳俊龍",
-        "lang:en_US": "CHEN, Leon"
+        "lang:zh-tw": "陳俊龍",
+        "lang:en": "CHEN, Leon"
       },
       "id": "Q24835400",
       "identifiers": [
@@ -48,7 +48,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林哲凌"
+        "lang:zh-tw": "林哲凌"
       },
       "id": "Q28413224",
       "identifiers": [
@@ -63,8 +63,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林深",
-        "lang:en_US": "Lin Shensou"
+        "lang:zh-tw": "林深",
+        "lang:en": "Lin Shensou"
       },
       "id": "Q45505717",
       "identifiers": [
@@ -79,8 +79,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃凱",
-        "lang:en_US": "Huang Kai"
+        "lang:zh-tw": "黃凱",
+        "lang:en": "Huang Kai"
       },
       "id": "Q45678955",
       "identifiers": [
@@ -95,8 +95,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李培元",
-        "lang:en_US": "Li Peiyuan"
+        "lang:zh-tw": "李培元",
+        "lang:en": "Li Peiyuan"
       },
       "id": "Q45706440",
       "identifiers": [
@@ -111,7 +111,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴淑娞"
+        "lang:zh-tw": "賴淑娞"
       },
       "id": "Q50090019",
       "identifiers": [
@@ -126,7 +126,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王又民"
+        "lang:zh-tw": "王又民"
       },
       "id": "Q50090066",
       "identifiers": [
@@ -141,7 +141,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "江文登"
+        "lang:zh-tw": "江文登"
       },
       "id": "Q50090110",
       "identifiers": [
@@ -156,7 +156,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林聖爵"
+        "lang:zh-tw": "林聖爵"
       },
       "id": "Q50090155",
       "identifiers": [
@@ -171,7 +171,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鍾明馨"
+        "lang:zh-tw": "鍾明馨"
       },
       "id": "Q50090204",
       "identifiers": [
@@ -186,7 +186,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周秀月"
+        "lang:zh-tw": "周秀月"
       },
       "id": "Q50090242",
       "identifiers": [
@@ -201,7 +201,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李建昇"
+        "lang:zh-tw": "李建昇"
       },
       "id": "Q50090292",
       "identifiers": [
@@ -216,7 +216,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李建志"
+        "lang:zh-tw": "李建志"
       },
       "id": "Q50090337",
       "identifiers": [
@@ -231,7 +231,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林岳璋"
+        "lang:zh-tw": "林岳璋"
       },
       "id": "Q50090376",
       "identifiers": [
@@ -246,7 +246,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "沈銘恭"
+        "lang:zh-tw": "沈銘恭"
       },
       "id": "Q50090416",
       "identifiers": [
@@ -261,7 +261,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳滄得"
+        "lang:zh-tw": "吳滄得"
       },
       "id": "Q50090450",
       "identifiers": [
@@ -276,7 +276,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王秋足"
+        "lang:zh-tw": "王秋足"
       },
       "id": "Q50090482",
       "identifiers": [
@@ -291,7 +291,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳樹吉"
+        "lang:zh-tw": "陳樹吉"
       },
       "id": "Q50090521",
       "identifiers": [
@@ -306,7 +306,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡東富"
+        "lang:zh-tw": "蔡東富"
       },
       "id": "Q50090560",
       "identifiers": [
@@ -321,7 +321,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴明源"
+        "lang:zh-tw": "賴明源"
       },
       "id": "Q50090604",
       "identifiers": [
@@ -336,7 +336,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "簡慈坊"
+        "lang:zh-tw": "簡慈坊"
       },
       "id": "Q50090634",
       "identifiers": [
@@ -351,7 +351,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王士壬"
+        "lang:zh-tw": "王士壬"
       },
       "id": "Q50090748",
       "identifiers": [
@@ -366,7 +366,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃鈺惠"
+        "lang:zh-tw": "黃鈺惠"
       },
       "id": "Q50090833",
       "identifiers": [
@@ -381,7 +381,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顏旭懋"
+        "lang:zh-tw": "顏旭懋"
       },
       "id": "Q50090872",
       "identifiers": [
@@ -396,7 +396,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳瑞雄"
+        "lang:zh-tw": "陳瑞雄"
       },
       "id": "Q50090961",
       "identifiers": [
@@ -411,7 +411,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "沈宗隆"
+        "lang:zh-tw": "沈宗隆"
       },
       "id": "Q50091003",
       "identifiers": [
@@ -426,7 +426,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖秋萍"
+        "lang:zh-tw": "廖秋萍"
       },
       "id": "Q50091046",
       "identifiers": [
@@ -441,7 +441,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王鐵道"
+        "lang:zh-tw": "王鐵道"
       },
       "id": "Q50091151",
       "identifiers": [
@@ -456,7 +456,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蕭澤梧"
+        "lang:zh-tw": "蕭澤梧"
       },
       "id": "Q50091186",
       "identifiers": [
@@ -471,7 +471,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "梁銘忠"
+        "lang:zh-tw": "梁銘忠"
       },
       "id": "Q50091224",
       "identifiers": [
@@ -486,7 +486,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖錦珠"
+        "lang:zh-tw": "廖錦珠"
       },
       "id": "Q50091256",
       "identifiers": [
@@ -501,7 +501,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃淑鈴"
+        "lang:zh-tw": "黃淑鈴"
       },
       "id": "Q50091294",
       "identifiers": [
@@ -516,7 +516,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林建鴻"
+        "lang:zh-tw": "林建鴻"
       },
       "id": "Q50091335",
       "identifiers": [
@@ -531,7 +531,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張健福"
+        "lang:zh-tw": "張健福"
       },
       "id": "Q50091447",
       "identifiers": [
@@ -546,7 +546,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇俊豪"
+        "lang:zh-tw": "蘇俊豪"
       },
       "id": "Q50091516",
       "identifiers": [
@@ -561,7 +561,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃勝賢"
+        "lang:zh-tw": "黃勝賢"
       },
       "id": "Q50091547",
       "identifiers": [
@@ -576,7 +576,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡岳儒"
+        "lang:zh-tw": "蔡岳儒"
       },
       "id": "Q50091607",
       "identifiers": [
@@ -591,7 +591,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃文祥"
+        "lang:zh-tw": "黃文祥"
       },
       "id": "Q50091646",
       "identifiers": [
@@ -606,7 +606,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡孟真"
+        "lang:zh-tw": "蔡孟真"
       },
       "id": "Q50091682",
       "identifiers": [
@@ -621,7 +621,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "翁水上"
+        "lang:zh-tw": "翁水上"
       },
       "id": "Q50091714",
       "identifiers": [
@@ -636,7 +636,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李明哲"
+        "lang:zh-tw": "李明哲"
       },
       "id": "Q50185315",
       "identifiers": [
@@ -651,7 +651,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許志豪"
+        "lang:zh-tw": "許志豪"
       },
       "id": "Q9044247",
       "identifiers": [
@@ -668,8 +668,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "雲林縣議會",
-        "lang:en_US": "Yunlin County Council"
+        "lang:zh-tw": "雲林縣議會",
+        "lang:en": "Yunlin County Council"
       },
       "id": "Q15908941",
       "classification": "branch",
@@ -686,8 +686,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -700,8 +700,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "台灣團結聯盟",
-        "lang:en_US": "Taiwan Solidarity Union"
+        "lang:zh-tw": "台灣團結聯盟",
+        "lang:en": "Taiwan Solidarity Union"
       },
       "id": "Q706834",
       "classification": "party",
@@ -714,8 +714,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -744,8 +744,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -769,8 +769,8 @@
         "Q49257574"
       ],
       "type": {
-        "lang:zh_TW": "雲林縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yunlin County"
+        "lang:zh-tw": "雲林縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
         "lang:zh_TW": "雲林縣第01選區"
@@ -793,8 +793,8 @@
         "Q49257574"
       ],
       "type": {
-        "lang:zh_TW": "雲林縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yunlin County"
+        "lang:zh-tw": "雲林縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
         "lang:zh_TW": "雲林縣第02選區"
@@ -817,8 +817,8 @@
         "Q49257574"
       ],
       "type": {
-        "lang:zh_TW": "雲林縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yunlin County"
+        "lang:zh-tw": "雲林縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
         "lang:zh_TW": "雲林縣第03選區"
@@ -841,8 +841,8 @@
         "Q49257574"
       ],
       "type": {
-        "lang:zh_TW": "雲林縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yunlin County"
+        "lang:zh-tw": "雲林縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
         "lang:zh_TW": "雲林縣第04選區"
@@ -865,8 +865,8 @@
         "Q49257574"
       ],
       "type": {
-        "lang:zh_TW": "雲林縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yunlin County"
+        "lang:zh-tw": "雲林縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
         "lang:zh_TW": "雲林縣第05選區"
@@ -889,8 +889,8 @@
         "Q49257574"
       ],
       "type": {
-        "lang:zh_TW": "雲林縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yunlin County"
+        "lang:zh-tw": "雲林縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
         "lang:zh_TW": "雲林縣第06選區"
@@ -913,8 +913,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -932,12 +932,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -949,12 +949,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -965,12 +965,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -983,12 +983,12 @@
       "end_date": "2016-09-11",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -999,12 +999,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1016,12 +1016,12 @@
       "end_date": "2016-03-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1032,12 +1032,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1049,12 +1049,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1065,12 +1065,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1082,12 +1082,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1099,12 +1099,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1115,12 +1115,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1132,12 +1132,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1149,12 +1149,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1165,12 +1165,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1181,12 +1181,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1197,12 +1197,12 @@
       "start_date": "2016-04-18",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1214,12 +1214,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1231,12 +1231,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1247,12 +1247,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1263,12 +1263,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1279,12 +1279,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1296,12 +1296,12 @@
       "end_date": "2016-04-18",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1313,12 +1313,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1329,12 +1329,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1346,12 +1346,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1363,12 +1363,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1380,12 +1380,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1397,12 +1397,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1413,12 +1413,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1430,12 +1430,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1446,12 +1446,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1462,12 +1462,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1479,12 +1479,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1495,12 +1495,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1512,12 +1512,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1528,12 +1528,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1544,12 +1544,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1561,12 +1561,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1577,12 +1577,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1593,12 +1593,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1609,12 +1609,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1626,12 +1626,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     },
     {
@@ -1643,12 +1643,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257574",
       "role": {
-        "lang:zh_TW": "雲林縣議員"
+        "lang:zh-tw": "雲林縣議員"
       }
     }
   ]

--- a/legislative/Q15909148/Q49995992/popolo-m17n.json
+++ b/legislative/Q15909148/Q49995992/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "薛呈懿"
+        "lang:zh-tw": "薛呈懿"
       },
       "id": "Q18753688",
       "identifiers": [
@@ -17,8 +17,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳宏謀",
-        "lang:en_US": "Wu Hong-mo"
+        "lang:zh-tw": "吳宏謀",
+        "lang:en": "Wu Hong-mo"
       },
       "id": "Q23883800",
       "identifiers": [
@@ -33,8 +33,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳文昌",
-        "lang:en_US": "Chen Wenchang"
+        "lang:zh-tw": "陳文昌",
+        "lang:en": "Chen Wenchang"
       },
       "id": "Q45467036",
       "identifiers": [
@@ -49,8 +49,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張建榮",
-        "lang:en_US": "Zhang Jianrong"
+        "lang:zh-tw": "張建榮",
+        "lang:en": "Zhang Jianrong"
       },
       "id": "Q45633180",
       "identifiers": [
@@ -65,7 +65,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃定和"
+        "lang:zh-tw": "黃定和"
       },
       "id": "Q47689441",
       "identifiers": [
@@ -80,7 +80,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊順木"
+        "lang:zh-tw": "楊順木"
       },
       "id": "Q50063458",
       "identifiers": [
@@ -95,7 +95,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林岳賢"
+        "lang:zh-tw": "林岳賢"
       },
       "id": "Q50063500",
       "identifiers": [
@@ -110,7 +110,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林志鴻"
+        "lang:zh-tw": "林志鴻"
       },
       "id": "Q50063596",
       "identifiers": [
@@ -125,7 +125,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "江碧華"
+        "lang:zh-tw": "江碧華"
       },
       "id": "Q50063637",
       "identifiers": [
@@ -140,7 +140,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林錫明"
+        "lang:zh-tw": "林錫明"
       },
       "id": "Q50063674",
       "identifiers": [
@@ -155,7 +155,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡文益"
+        "lang:zh-tw": "蔡文益"
       },
       "id": "Q50063715",
       "identifiers": [
@@ -170,7 +170,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林東成"
+        "lang:zh-tw": "林東成"
       },
       "id": "Q50063725",
       "identifiers": [
@@ -185,7 +185,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林金龍"
+        "lang:zh-tw": "林金龍"
       },
       "id": "Q50063779",
       "identifiers": [
@@ -200,7 +200,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林成功"
+        "lang:zh-tw": "林成功"
       },
       "id": "Q50063823",
       "identifiers": [
@@ -215,7 +215,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳俊宇"
+        "lang:zh-tw": "陳俊宇"
       },
       "id": "Q50063892",
       "identifiers": [
@@ -230,7 +230,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃浴沂"
+        "lang:zh-tw": "黃浴沂"
       },
       "id": "Q50063929",
       "identifiers": [
@@ -245,7 +245,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳福山"
+        "lang:zh-tw": "陳福山"
       },
       "id": "Q50063980",
       "identifiers": [
@@ -260,7 +260,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃建勇"
+        "lang:zh-tw": "黃建勇"
       },
       "id": "Q50064026",
       "identifiers": [
@@ -275,7 +275,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉添梧"
+        "lang:zh-tw": "劉添梧"
       },
       "id": "Q50064069",
       "identifiers": [
@@ -290,7 +290,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳鴻禧"
+        "lang:zh-tw": "陳鴻禧"
       },
       "id": "Q50064108",
       "identifiers": [
@@ -305,7 +305,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳秋齡"
+        "lang:zh-tw": "吳秋齡"
       },
       "id": "Q50064140",
       "identifiers": [
@@ -320,7 +320,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃素琴"
+        "lang:zh-tw": "黃素琴"
       },
       "id": "Q50064184",
       "identifiers": [
@@ -335,7 +335,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳漢鍾"
+        "lang:zh-tw": "陳漢鍾"
       },
       "id": "Q50064224",
       "identifiers": [
@@ -350,7 +350,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "沈德茂"
+        "lang:zh-tw": "沈德茂"
       },
       "id": "Q50064262",
       "identifiers": [
@@ -365,7 +365,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃適超"
+        "lang:zh-tw": "黃適超"
       },
       "id": "Q50064306",
       "identifiers": [
@@ -380,7 +380,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張明華"
+        "lang:zh-tw": "張明華"
       },
       "id": "Q50064346",
       "identifiers": [
@@ -395,7 +395,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "游祥德"
+        "lang:zh-tw": "游祥德"
       },
       "id": "Q50064383",
       "identifiers": [
@@ -410,7 +410,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊政誠"
+        "lang:zh-tw": "楊政誠"
       },
       "id": "Q50064467",
       "identifiers": [
@@ -425,7 +425,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張秋明"
+        "lang:zh-tw": "張秋明"
       },
       "id": "Q50064514",
       "identifiers": [
@@ -440,7 +440,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱嘉進"
+        "lang:zh-tw": "邱嘉進"
       },
       "id": "Q50064595",
       "identifiers": [
@@ -455,7 +455,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳正男"
+        "lang:zh-tw": "陳正男"
       },
       "id": "Q50064636",
       "identifiers": [
@@ -470,7 +470,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林棋山"
+        "lang:zh-tw": "林棋山"
       },
       "id": "Q50064676",
       "identifiers": [
@@ -485,7 +485,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "孫湯玉惠"
+        "lang:zh-tw": "孫湯玉惠"
       },
       "id": "Q50064711",
       "identifiers": [
@@ -500,7 +500,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳傑麟"
+        "lang:zh-tw": "陳傑麟"
       },
       "id": "Q50064740",
       "identifiers": [
@@ -515,7 +515,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳孝仁"
+        "lang:zh-tw": "陳孝仁"
       },
       "id": "Q50064775",
       "identifiers": [
@@ -532,8 +532,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "宜蘭縣議會",
-        "lang:en_US": "Yilan County Council"
+        "lang:zh-tw": "宜蘭縣議會",
+        "lang:en": "Yilan County Council"
       },
       "id": "Q15909148",
       "classification": "branch",
@@ -550,8 +550,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -564,7 +564,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "在野問政聯盟"
+        "lang:zh-tw": "在野問政聯盟"
       },
       "id": "Q50059076",
       "classification": "party",
@@ -577,8 +577,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -607,8 +607,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -632,8 +632,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第01選區"
@@ -656,8 +656,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第02選區"
@@ -680,8 +680,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第03選區"
@@ -704,8 +704,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第04選區"
@@ -728,8 +728,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第05選區"
@@ -752,8 +752,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第06選區"
@@ -776,8 +776,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第07選區"
@@ -800,8 +800,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第08選區"
@@ -824,8 +824,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第09選區"
@@ -848,8 +848,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第10選區"
@@ -872,8 +872,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第11選區"
@@ -896,8 +896,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第12選區"
@@ -920,8 +920,8 @@
         "Q49254881"
       ],
       "type": {
-        "lang:zh_TW": "宜蘭縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Yilan County"
+        "lang:zh-tw": "宜蘭縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣第13選區"
@@ -944,8 +944,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -963,12 +963,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -980,12 +980,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -997,12 +997,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1014,12 +1014,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1031,12 +1031,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1048,12 +1048,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1065,12 +1065,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1082,12 +1082,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1098,12 +1098,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1115,12 +1115,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1132,12 +1132,12 @@
       "start_date": "2015-06-03",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1149,12 +1149,12 @@
       "end_date": "2015-06-03",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1166,12 +1166,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1183,12 +1183,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1200,12 +1200,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1217,12 +1217,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1234,12 +1234,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1251,12 +1251,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1268,12 +1268,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1285,12 +1285,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1302,12 +1302,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1319,12 +1319,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1336,12 +1336,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1353,12 +1353,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1370,12 +1370,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1387,12 +1387,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1404,12 +1404,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1422,12 +1422,12 @@
       "end_date": "2016-08-13",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1439,12 +1439,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1456,12 +1456,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1473,12 +1473,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1489,12 +1489,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1505,12 +1505,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1521,12 +1521,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     },
     {
@@ -1538,12 +1538,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49254881",
       "role": {
-        "lang:zh_TW": "宜蘭縣議員"
+        "lang:zh-tw": "宜蘭縣議員"
       }
     }
   ]

--- a/legislative/Q15909304/Q49996593/popolo-m17n.json
+++ b/legislative/Q15909304/Q49996593/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "魏嘉賢"
+        "lang:zh-tw": "魏嘉賢"
       },
       "id": "Q27150807",
       "identifiers": [
@@ -17,8 +17,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉曉玫",
-        "lang:en_US": "Liuh Siao-Mei"
+        "lang:zh-tw": "劉曉玫",
+        "lang:en": "Liuh Siao-Mei"
       },
       "id": "Q28408602",
       "identifiers": [
@@ -33,8 +33,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳長明",
-        "lang:en_US": "Chen Changming"
+        "lang:zh-tw": "陳長明",
+        "lang:en": "Chen Changming"
       },
       "id": "Q45476183",
       "identifiers": [
@@ -49,7 +49,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張峻"
+        "lang:zh-tw": "張峻"
       },
       "id": "Q48928430",
       "identifiers": [
@@ -64,7 +64,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "施金樹"
+        "lang:zh-tw": "施金樹"
       },
       "id": "Q50085509",
       "identifiers": [
@@ -79,7 +79,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林宗昆"
+        "lang:zh-tw": "林宗昆"
       },
       "id": "Q50085552",
       "identifiers": [
@@ -94,7 +94,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "莊枝財"
+        "lang:zh-tw": "莊枝財"
       },
       "id": "Q50085682",
       "identifiers": [
@@ -109,7 +109,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊文值"
+        "lang:zh-tw": "楊文值"
       },
       "id": "Q50085709",
       "identifiers": [
@@ -124,7 +124,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李秋旺"
+        "lang:zh-tw": "李秋旺"
       },
       "id": "Q50085743",
       "identifiers": [
@@ -139,7 +139,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝國榮"
+        "lang:zh-tw": "謝國榮"
       },
       "id": "Q50085776",
       "identifiers": [
@@ -154,7 +154,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴進坤"
+        "lang:zh-tw": "賴進坤"
       },
       "id": "Q50085809",
       "identifiers": [
@@ -169,7 +169,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何禮臺"
+        "lang:zh-tw": "何禮臺"
       },
       "id": "Q50085858",
       "identifiers": [
@@ -184,7 +184,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "葉鯤璟"
+        "lang:zh-tw": "葉鯤璟"
       },
       "id": "Q50085897",
       "identifiers": [
@@ -199,7 +199,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱永双"
+        "lang:zh-tw": "邱永双"
       },
       "id": "Q50085928",
       "identifiers": [
@@ -214,7 +214,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張正治"
+        "lang:zh-tw": "張正治"
       },
       "id": "Q50085965",
       "identifiers": [
@@ -229,7 +229,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐雪玉"
+        "lang:zh-tw": "徐雪玉"
       },
       "id": "Q50086001",
       "identifiers": [
@@ -244,7 +244,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "游淑貞"
+        "lang:zh-tw": "游淑貞"
       },
       "id": "Q50086042",
       "identifiers": [
@@ -259,7 +259,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭乾龍"
+        "lang:zh-tw": "鄭乾龍"
       },
       "id": "Q50086121",
       "identifiers": [
@@ -274,7 +274,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "游美雲"
+        "lang:zh-tw": "游美雲"
       },
       "id": "Q50086155",
       "identifiers": [
@@ -289,7 +289,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃振富"
+        "lang:zh-tw": "黃振富"
       },
       "id": "Q50086196",
       "identifiers": [
@@ -304,7 +304,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張智冠"
+        "lang:zh-tw": "張智冠"
       },
       "id": "Q50086236",
       "identifiers": [
@@ -319,7 +319,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王燕美"
+        "lang:zh-tw": "王燕美"
       },
       "id": "Q50086270",
       "identifiers": [
@@ -334,7 +334,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "潘富民"
+        "lang:zh-tw": "潘富民"
       },
       "id": "Q50086308",
       "identifiers": [
@@ -349,7 +349,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林秋美"
+        "lang:zh-tw": "林秋美"
       },
       "id": "Q50086357",
       "identifiers": [
@@ -364,7 +364,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "余夏夫"
+        "lang:zh-tw": "余夏夫"
       },
       "id": "Q50086394",
       "identifiers": [
@@ -379,7 +379,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "笛布斯顗賚"
+        "lang:zh-tw": "笛布斯顗賚"
       },
       "id": "Q50086439",
       "identifiers": [
@@ -394,7 +394,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊德金"
+        "lang:zh-tw": "楊德金"
       },
       "id": "Q50086477",
       "identifiers": [
@@ -409,7 +409,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "萬榮財"
+        "lang:zh-tw": "萬榮財"
       },
       "id": "Q50086519",
       "identifiers": [
@@ -424,7 +424,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳英妹"
+        "lang:zh-tw": "陳英妹"
       },
       "id": "Q50086559",
       "identifiers": [
@@ -439,7 +439,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳建忠"
+        "lang:zh-tw": "陳建忠"
       },
       "id": "Q50086599",
       "identifiers": [
@@ -454,7 +454,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許淑銀"
+        "lang:zh-tw": "許淑銀"
       },
       "id": "Q50086641",
       "identifiers": [
@@ -469,7 +469,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇忠亮"
+        "lang:zh-tw": "蘇忠亮"
       },
       "id": "Q50086717",
       "identifiers": [
@@ -484,7 +484,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "施慧萍"
+        "lang:zh-tw": "施慧萍"
       },
       "id": "Q8276916",
       "identifiers": [
@@ -501,8 +501,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "花蓮縣議會",
-        "lang:en_US": "Hualien County Council"
+        "lang:zh-tw": "花蓮縣議會",
+        "lang:en": "Hualien County Council"
       },
       "id": "Q15909304",
       "classification": "branch",
@@ -519,8 +519,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -533,8 +533,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -563,8 +563,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -588,8 +588,8 @@
         "Q49256840"
       ],
       "type": {
-        "lang:zh_TW": "花蓮縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hualien County"
+        "lang:zh-tw": "花蓮縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
         "lang:zh_TW": "花蓮縣第01選區"
@@ -612,8 +612,8 @@
         "Q49256840"
       ],
       "type": {
-        "lang:zh_TW": "花蓮縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hualien County"
+        "lang:zh-tw": "花蓮縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
         "lang:zh_TW": "花蓮縣第02選區"
@@ -636,8 +636,8 @@
         "Q49256840"
       ],
       "type": {
-        "lang:zh_TW": "花蓮縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hualien County"
+        "lang:zh-tw": "花蓮縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
         "lang:zh_TW": "花蓮縣第03選區"
@@ -660,8 +660,8 @@
         "Q49256840"
       ],
       "type": {
-        "lang:zh_TW": "花蓮縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hualien County"
+        "lang:zh-tw": "花蓮縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
         "lang:zh_TW": "花蓮縣第04選區"
@@ -684,8 +684,8 @@
         "Q49256840"
       ],
       "type": {
-        "lang:zh_TW": "花蓮縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hualien County"
+        "lang:zh-tw": "花蓮縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
         "lang:zh_TW": "花蓮縣第05選區"
@@ -708,8 +708,8 @@
         "Q49256840"
       ],
       "type": {
-        "lang:zh_TW": "花蓮縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hualien County"
+        "lang:zh-tw": "花蓮縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
         "lang:zh_TW": "花蓮縣第06選區"
@@ -732,8 +732,8 @@
         "Q49256840"
       ],
       "type": {
-        "lang:zh_TW": "花蓮縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hualien County"
+        "lang:zh-tw": "花蓮縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
         "lang:zh_TW": "花蓮縣第07選區"
@@ -756,8 +756,8 @@
         "Q49256840"
       ],
       "type": {
-        "lang:zh_TW": "花蓮縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hualien County"
+        "lang:zh-tw": "花蓮縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
         "lang:zh_TW": "花蓮縣第08選區"
@@ -780,8 +780,8 @@
         "Q49256840"
       ],
       "type": {
-        "lang:zh_TW": "花蓮縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hualien County"
+        "lang:zh-tw": "花蓮縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
         "lang:zh_TW": "花蓮縣第09選區"
@@ -804,8 +804,8 @@
         "Q49256840"
       ],
       "type": {
-        "lang:zh_TW": "花蓮縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Hualien County"
+        "lang:zh-tw": "花蓮縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
         "lang:zh_TW": "花蓮縣第10選區"
@@ -828,8 +828,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -849,12 +849,12 @@
       "end_date": "2016-09-02",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -866,12 +866,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -883,12 +883,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -900,12 +900,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -917,12 +917,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -934,12 +934,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -951,12 +951,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -968,12 +968,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -985,12 +985,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1002,12 +1002,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1019,12 +1019,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1036,12 +1036,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1052,12 +1052,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1069,12 +1069,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1086,12 +1086,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1103,12 +1103,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1119,12 +1119,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1136,12 +1136,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1153,12 +1153,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1170,12 +1170,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1187,12 +1187,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1203,12 +1203,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1220,12 +1220,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1236,12 +1236,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1253,12 +1253,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1269,12 +1269,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1286,12 +1286,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1302,12 +1302,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1318,12 +1318,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1335,12 +1335,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1352,12 +1352,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1369,12 +1369,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     },
     {
@@ -1386,12 +1386,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256840",
       "role": {
-        "lang:zh_TW": "花蓮縣議員"
+        "lang:zh-tw": "花蓮縣議員"
       }
     }
   ]

--- a/legislative/Q15914537/Q49996694/popolo-m17n.json
+++ b/legislative/Q15914537/Q49996694/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "李應文",
-        "lang:en_US": "Li Yingwen"
+        "lang:zh-tw": "李應文",
+        "lang:en": "Li Yingwen"
       },
       "id": "Q45517813",
       "identifiers": [
@@ -18,8 +18,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊萬山",
-        "lang:en_US": "Yang Wanshan"
+        "lang:zh-tw": "楊萬山",
+        "lang:en": "Yang Wanshan"
       },
       "id": "Q45623338",
       "identifiers": [
@@ -34,7 +34,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳玉珍"
+        "lang:zh-tw": "陳玉珍"
       },
       "id": "Q48896684",
       "identifiers": [
@@ -49,7 +49,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪允典"
+        "lang:zh-tw": "洪允典"
       },
       "id": "Q50088980",
       "identifiers": [
@@ -64,7 +64,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "石永城"
+        "lang:zh-tw": "石永城"
       },
       "id": "Q50089025",
       "identifiers": [
@@ -79,7 +79,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "唐麗輝"
+        "lang:zh-tw": "唐麗輝"
       },
       "id": "Q50089076",
       "identifiers": [
@@ -94,7 +94,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許建中"
+        "lang:zh-tw": "許建中"
       },
       "id": "Q50089119",
       "identifiers": [
@@ -109,7 +109,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許玉昭"
+        "lang:zh-tw": "許玉昭"
       },
       "id": "Q50089160",
       "identifiers": [
@@ -124,7 +124,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李誠智"
+        "lang:zh-tw": "李誠智"
       },
       "id": "Q50089255",
       "identifiers": [
@@ -139,7 +139,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林孫全"
+        "lang:zh-tw": "林孫全"
       },
       "id": "Q50089308",
       "identifiers": [
@@ -154,7 +154,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王碧珍"
+        "lang:zh-tw": "王碧珍"
       },
       "id": "Q50089360",
       "identifiers": [
@@ -169,7 +169,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許華玉"
+        "lang:zh-tw": "許華玉"
       },
       "id": "Q50089399",
       "identifiers": [
@@ -184,7 +184,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊永立"
+        "lang:zh-tw": "楊永立"
       },
       "id": "Q50089434",
       "identifiers": [
@@ -199,7 +199,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "歐陽儀雄"
+        "lang:zh-tw": "歐陽儀雄"
       },
       "id": "Q50089478",
       "identifiers": [
@@ -214,7 +214,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周子傑"
+        "lang:zh-tw": "周子傑"
       },
       "id": "Q50089581",
       "identifiers": [
@@ -229,7 +229,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝東龍"
+        "lang:zh-tw": "謝東龍"
       },
       "id": "Q50089625",
       "identifiers": [
@@ -244,7 +244,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡水游"
+        "lang:zh-tw": "蔡水游"
       },
       "id": "Q50089671",
       "identifiers": [
@@ -259,7 +259,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張雲德"
+        "lang:zh-tw": "張雲德"
       },
       "id": "Q50089719",
       "identifiers": [
@@ -274,7 +274,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡春生"
+        "lang:zh-tw": "蔡春生"
       },
       "id": "Q50089771",
       "identifiers": [
@@ -289,7 +289,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪鴻斌"
+        "lang:zh-tw": "洪鴻斌"
       },
       "id": "Q50089917",
       "identifiers": [
@@ -304,7 +304,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪麗萍"
+        "lang:zh-tw": "洪麗萍"
       },
       "id": "Q50089974",
       "identifiers": [
@@ -319,7 +319,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳滄江"
+        "lang:zh-tw": "陳滄江"
       },
       "id": "Q8348051",
       "identifiers": [
@@ -336,8 +336,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "金門縣議會",
-        "lang:en_US": "Kinmen County Council"
+        "lang:zh-tw": "金門縣議會",
+        "lang:en": "Kinmen County Council"
       },
       "id": "Q15914537",
       "classification": "branch",
@@ -354,8 +354,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -368,8 +368,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -398,8 +398,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -423,8 +423,8 @@
         "Q49257377"
       ],
       "type": {
-        "lang:zh_TW": "金門縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kinmen"
+        "lang:zh-tw": "金門縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kinmen"
       },
       "name": {
         "lang:zh_TW": "金門縣第01選區"
@@ -447,8 +447,8 @@
         "Q49257377"
       ],
       "type": {
-        "lang:zh_TW": "金門縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kinmen"
+        "lang:zh-tw": "金門縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kinmen"
       },
       "name": {
         "lang:zh_TW": "金門縣第02選區"
@@ -471,8 +471,8 @@
         "Q49257377"
       ],
       "type": {
-        "lang:zh_TW": "金門縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kinmen"
+        "lang:zh-tw": "金門縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kinmen"
       },
       "name": {
         "lang:zh_TW": "金門縣第03選區"
@@ -495,8 +495,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -515,12 +515,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -533,12 +533,12 @@
       "end_date": "2016-01-15",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -549,12 +549,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -566,12 +566,12 @@
       "start_date": "2016-07-22",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -583,12 +583,12 @@
       "end_date": "2016-07-22",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -599,12 +599,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -616,12 +616,12 @@
       "start_date": "2015-09-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -633,12 +633,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -650,12 +650,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -668,12 +668,12 @@
       "end_date": "2015-09-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -685,12 +685,12 @@
       "start_date": "2016-01-15",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -702,12 +702,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -719,12 +719,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -736,12 +736,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -753,12 +753,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -770,12 +770,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -787,12 +787,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -804,12 +804,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -821,12 +821,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -838,12 +838,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -855,12 +855,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     },
     {
@@ -872,12 +872,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257377",
       "role": {
-        "lang:zh_TW": "金門縣議員"
+        "lang:zh-tw": "金門縣議員"
       }
     }
   ]

--- a/legislative/Q15915051/Q49996554/popolo-m17n.json
+++ b/legislative/Q15915051/Q49996554/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "張再興",
-        "lang:en_US": "Chang Tsai-Hsing"
+        "lang:zh-tw": "張再興",
+        "lang:en": "Chang Tsai-Hsing"
       },
       "id": "Q15921222",
       "identifiers": [
@@ -18,7 +18,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳振中"
+        "lang:zh-tw": "陳振中"
       },
       "id": "Q15933673",
       "identifiers": [
@@ -33,7 +33,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳慧玲"
+        "lang:zh-tw": "陳慧玲"
       },
       "id": "Q28415458",
       "identifiers": [
@@ -48,8 +48,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "呂啟宗",
-        "lang:en_US": "Lv Qizong"
+        "lang:zh-tw": "呂啟宗",
+        "lang:en": "Lv Qizong"
       },
       "id": "Q45433195",
       "identifiers": [
@@ -64,7 +64,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳佩真"
+        "lang:zh-tw": "陳佩真"
       },
       "id": "Q47672130",
       "identifiers": [
@@ -79,7 +79,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉陳昭玲"
+        "lang:zh-tw": "劉陳昭玲"
       },
       "id": "Q50077509",
       "identifiers": [
@@ -94,7 +94,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳海山"
+        "lang:zh-tw": "陳海山"
       },
       "id": "Q50077550",
       "identifiers": [
@@ -109,7 +109,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳文相"
+        "lang:zh-tw": "吳文相"
       },
       "id": "Q50077613",
       "identifiers": [
@@ -124,7 +124,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇陳綉色"
+        "lang:zh-tw": "蘇陳綉色"
       },
       "id": "Q50077638",
       "identifiers": [
@@ -139,7 +139,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "藍俊逸"
+        "lang:zh-tw": "藍俊逸"
       },
       "id": "Q50077664",
       "identifiers": [
@@ -154,7 +154,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃春燕"
+        "lang:zh-tw": "黃春燕"
       },
       "id": "Q50077706",
       "identifiers": [
@@ -169,7 +169,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡清續"
+        "lang:zh-tw": "蔡清續"
       },
       "id": "Q50077734",
       "identifiers": [
@@ -184,7 +184,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "呂黃春金"
+        "lang:zh-tw": "呂黃春金"
       },
       "id": "Q50077847",
       "identifiers": [
@@ -199,7 +199,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "胡松榮"
+        "lang:zh-tw": "胡松榮"
       },
       "id": "Q50077892",
       "identifiers": [
@@ -214,7 +214,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顏嘉弘"
+        "lang:zh-tw": "顏嘉弘"
       },
       "id": "Q50077936",
       "identifiers": [
@@ -229,7 +229,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "歐陽洲"
+        "lang:zh-tw": "歐陽洲"
       },
       "id": "Q50077993",
       "identifiers": [
@@ -244,7 +244,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "成萬貫"
+        "lang:zh-tw": "成萬貫"
       },
       "id": "Q50078082",
       "identifiers": [
@@ -259,7 +259,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳百川"
+        "lang:zh-tw": "陳百川"
       },
       "id": "Q50078136",
       "identifiers": [
@@ -274,7 +274,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "魏長源"
+        "lang:zh-tw": "魏長源"
       },
       "id": "Q50078195",
       "identifiers": [
@@ -289,7 +289,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "宋國進"
+        "lang:zh-tw": "宋國進"
       },
       "id": "Q50078242",
       "identifiers": [
@@ -304,7 +304,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊石龍"
+        "lang:zh-tw": "楊石龍"
       },
       "id": "Q50078276",
       "identifiers": [
@@ -319,7 +319,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "葉明縣"
+        "lang:zh-tw": "葉明縣"
       },
       "id": "Q50078352",
       "identifiers": [
@@ -334,7 +334,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳雙全"
+        "lang:zh-tw": "陳雙全"
       },
       "id": "Q50184747",
       "identifiers": [
@@ -351,8 +351,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "澎湖縣議會",
-        "lang:en_US": "Penghu County Council"
+        "lang:zh-tw": "澎湖縣議會",
+        "lang:en": "Penghu County Council"
       },
       "id": "Q15915051",
       "classification": "branch",
@@ -369,8 +369,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -383,8 +383,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "無黨團結聯盟",
-        "lang:en_US": "Non-Partisan Solidarity Union"
+        "lang:zh-tw": "無黨團結聯盟",
+        "lang:en": "Non-Partisan Solidarity Union"
       },
       "id": "Q718487",
       "classification": "party",
@@ -397,8 +397,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -427,8 +427,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -452,8 +452,8 @@
         "Q49255918"
       ],
       "type": {
-        "lang:zh_TW": "澎湖縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Penghu County"
+        "lang:zh-tw": "澎湖縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
         "lang:zh_TW": "澎湖縣第01選區"
@@ -476,8 +476,8 @@
         "Q49255918"
       ],
       "type": {
-        "lang:zh_TW": "澎湖縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Penghu County"
+        "lang:zh-tw": "澎湖縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
         "lang:zh_TW": "澎湖縣第02選區"
@@ -500,8 +500,8 @@
         "Q49255918"
       ],
       "type": {
-        "lang:zh_TW": "澎湖縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Penghu County"
+        "lang:zh-tw": "澎湖縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
         "lang:zh_TW": "澎湖縣第03選區"
@@ -524,8 +524,8 @@
         "Q49255918"
       ],
       "type": {
-        "lang:zh_TW": "澎湖縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Penghu County"
+        "lang:zh-tw": "澎湖縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
         "lang:zh_TW": "澎湖縣第04選區"
@@ -548,8 +548,8 @@
         "Q49255918"
       ],
       "type": {
-        "lang:zh_TW": "澎湖縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Penghu County"
+        "lang:zh-tw": "澎湖縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
         "lang:zh_TW": "澎湖縣第05選區"
@@ -572,8 +572,8 @@
         "Q49255918"
       ],
       "type": {
-        "lang:zh_TW": "澎湖縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Penghu County"
+        "lang:zh-tw": "澎湖縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
         "lang:zh_TW": "澎湖縣第06選區"
@@ -596,8 +596,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -616,12 +616,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -633,12 +633,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -650,12 +650,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -666,12 +666,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -682,12 +682,12 @@
       "start_date": "2016-07-04",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -699,12 +699,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -715,12 +715,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -732,12 +732,12 @@
       "end_date": "2015-12-08",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -748,12 +748,12 @@
       "start_date": "2015-12-08",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -765,12 +765,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -782,12 +782,12 @@
       "start_date": "2016-03-28",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -798,12 +798,12 @@
       "start_date": "2015-12-18",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -815,12 +815,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -832,12 +832,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -850,12 +850,12 @@
       "end_date": "2016-03-28",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -867,12 +867,12 @@
       "end_date": "2015-12-18",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -884,12 +884,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -902,12 +902,12 @@
       "end_date": "2016-03-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -918,12 +918,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -935,12 +935,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -951,12 +951,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -968,12 +968,12 @@
       "end_date": "2016-07-04",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     },
     {
@@ -985,12 +985,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49255918",
       "role": {
-        "lang:zh_TW": "澎湖縣議員"
+        "lang:zh-tw": "澎湖縣議員"
       }
     }
   ]

--- a/legislative/Q15919452/Q49996660/popolo-m17n.json
+++ b/legislative/Q15919452/Q49996660/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "曹丞君"
+        "lang:zh-tw": "曹丞君"
       },
       "id": "Q50088572",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曹以標"
+        "lang:zh-tw": "曹以標"
       },
       "id": "Q50088609",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳書建"
+        "lang:zh-tw": "陳書建"
       },
       "id": "Q50088647",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林貽祥"
+        "lang:zh-tw": "林貽祥"
       },
       "id": "Q50088703",
       "identifiers": [
@@ -62,7 +62,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林明揚"
+        "lang:zh-tw": "林明揚"
       },
       "id": "Q50088755",
       "identifiers": [
@@ -77,7 +77,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周瑞國"
+        "lang:zh-tw": "周瑞國"
       },
       "id": "Q50088805",
       "identifiers": [
@@ -92,7 +92,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳貴忠"
+        "lang:zh-tw": "陳貴忠"
       },
       "id": "Q50088846",
       "identifiers": [
@@ -107,7 +107,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳貽斌"
+        "lang:zh-tw": "陳貽斌"
       },
       "id": "Q50088893",
       "identifiers": [
@@ -122,7 +122,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張永江"
+        "lang:zh-tw": "張永江"
       },
       "id": "Q50088941",
       "identifiers": [
@@ -139,8 +139,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "連江縣議會",
-        "lang:en_US": "Lienchiang County Council"
+        "lang:zh-tw": "連江縣議會",
+        "lang:en": "Lienchiang County Council"
       },
       "id": "Q15919452",
       "classification": "branch",
@@ -157,8 +157,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -187,8 +187,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -212,8 +212,8 @@
         "Q49257199"
       ],
       "type": {
-        "lang:zh_TW": "連江縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Lienchiang County"
+        "lang:zh-tw": "連江縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Lienchiang County"
       },
       "name": {
         "lang:zh_TW": "連江縣第01選區"
@@ -236,8 +236,8 @@
         "Q49257199"
       ],
       "type": {
-        "lang:zh_TW": "連江縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Lienchiang County"
+        "lang:zh-tw": "連江縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Lienchiang County"
       },
       "name": {
         "lang:zh_TW": "連江縣第02選區"
@@ -260,8 +260,8 @@
         "Q49257199"
       ],
       "type": {
-        "lang:zh_TW": "連江縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Lienchiang County"
+        "lang:zh-tw": "連江縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Lienchiang County"
       },
       "name": {
         "lang:zh_TW": "連江縣第03選區"
@@ -284,8 +284,8 @@
         "Q49257199"
       ],
       "type": {
-        "lang:zh_TW": "連江縣議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Lienchiang County"
+        "lang:zh-tw": "連江縣議員選區",
+        "lang:en": "Constituency of Regional Councilors of Lienchiang County"
       },
       "name": {
         "lang:zh_TW": "連江縣第04選區"
@@ -308,8 +308,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -327,12 +327,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257199",
       "role": {
-        "lang:zh_TW": "連江縣議員"
+        "lang:zh-tw": "連江縣議員"
       }
     },
     {
@@ -343,12 +343,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257199",
       "role": {
-        "lang:zh_TW": "連江縣議員"
+        "lang:zh-tw": "連江縣議員"
       }
     },
     {
@@ -360,12 +360,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257199",
       "role": {
-        "lang:zh_TW": "連江縣議員"
+        "lang:zh-tw": "連江縣議員"
       }
     },
     {
@@ -377,12 +377,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257199",
       "role": {
-        "lang:zh_TW": "連江縣議員"
+        "lang:zh-tw": "連江縣議員"
       }
     },
     {
@@ -394,12 +394,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257199",
       "role": {
-        "lang:zh_TW": "連江縣議員"
+        "lang:zh-tw": "連江縣議員"
       }
     },
     {
@@ -411,12 +411,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257199",
       "role": {
-        "lang:zh_TW": "連江縣議員"
+        "lang:zh-tw": "連江縣議員"
       }
     },
     {
@@ -428,12 +428,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257199",
       "role": {
-        "lang:zh_TW": "連江縣議員"
+        "lang:zh-tw": "連江縣議員"
       }
     },
     {
@@ -445,12 +445,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257199",
       "role": {
-        "lang:zh_TW": "連江縣議員"
+        "lang:zh-tw": "連江縣議員"
       }
     },
     {
@@ -461,12 +461,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257199",
       "role": {
-        "lang:zh_TW": "連江縣議員"
+        "lang:zh-tw": "連江縣議員"
       }
     }
   ]

--- a/legislative/Q6366073/Q49996760/popolo-m17n.json
+++ b/legislative/Q6366073/Q49996760/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "陳麗珍",
-        "lang:en_US": "Vivian Chan"
+        "lang:zh-tw": "陳麗珍",
+        "lang:en": "Vivian Chan"
       },
       "id": "Q15931613",
       "identifiers": [
@@ -18,7 +18,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蕭永達"
+        "lang:zh-tw": "蕭永達"
       },
       "id": "Q16926846",
       "identifiers": [
@@ -33,7 +33,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳政聞"
+        "lang:zh-tw": "陳政聞"
       },
       "id": "Q16929428",
       "identifiers": [
@@ -48,7 +48,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林武忠"
+        "lang:zh-tw": "林武忠"
       },
       "id": "Q17026545",
       "identifiers": [
@@ -63,7 +63,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "康裕成"
+        "lang:zh-tw": "康裕成"
       },
       "id": "Q17499182",
       "identifiers": [
@@ -78,7 +78,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "俄鄧‧殷艾"
+        "lang:zh-tw": "俄鄧‧殷艾"
       },
       "id": "Q17499487",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王聖仁"
+        "lang:zh-tw": "王聖仁"
       },
       "id": "Q17500670",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許崑源"
+        "lang:zh-tw": "許崑源"
       },
       "id": "Q18415694",
       "identifiers": [
@@ -123,8 +123,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃淑美",
-        "lang:en_US": "Shu Mei Hwang"
+        "lang:zh-tw": "黃淑美",
+        "lang:en": "Shu Mei Hwang"
       },
       "id": "Q18985728",
       "identifiers": [
@@ -139,8 +139,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李喬如",
-        "lang:en_US": "Lee Chiao-Ju"
+        "lang:zh-tw": "李喬如",
+        "lang:en": "Lee Chiao-Ju"
       },
       "id": "Q21449421",
       "identifiers": [
@@ -155,7 +155,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡金晏"
+        "lang:zh-tw": "蔡金晏"
       },
       "id": "Q21449499",
       "identifiers": [
@@ -170,8 +170,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳美雅",
-        "lang:en_US": "Chen Mei-ya"
+        "lang:zh-tw": "陳美雅",
+        "lang:en": "Chen Mei-ya"
       },
       "id": "Q21449528",
       "identifiers": [
@@ -186,8 +186,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "簡煥宗",
-        "lang:en_US": "Chien Huan-Tsung"
+        "lang:zh-tw": "簡煥宗",
+        "lang:en": "Chien Huan-Tsung"
       },
       "id": "Q22101087",
       "identifiers": [
@@ -202,7 +202,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃紹庭"
+        "lang:zh-tw": "黃紹庭"
       },
       "id": "Q24837083",
       "identifiers": [
@@ -217,7 +217,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡昌達"
+        "lang:zh-tw": "蔡昌達"
       },
       "id": "Q24838279",
       "identifiers": [
@@ -232,7 +232,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭新助"
+        "lang:zh-tw": "鄭新助"
       },
       "id": "Q28413567",
       "identifiers": [
@@ -247,7 +247,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭建盟"
+        "lang:zh-tw": "郭建盟"
       },
       "id": "Q28414032",
       "identifiers": [
@@ -262,7 +262,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳信瑜"
+        "lang:zh-tw": "陳信瑜"
       },
       "id": "Q30941303",
       "identifiers": [
@@ -277,8 +277,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張文瑞",
-        "lang:en_US": "Zhang Wenrui"
+        "lang:zh-tw": "張文瑞",
+        "lang:en": "Zhang Wenrui"
       },
       "id": "Q45690219",
       "identifiers": [
@@ -293,7 +293,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何權峰"
+        "lang:zh-tw": "何權峰"
       },
       "id": "Q47546050",
       "identifiers": [
@@ -308,7 +308,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李柏毅"
+        "lang:zh-tw": "李柏毅"
       },
       "id": "Q47673767",
       "identifiers": [
@@ -323,7 +323,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李雅靜"
+        "lang:zh-tw": "李雅靜"
       },
       "id": "Q47691457",
       "identifiers": [
@@ -338,7 +338,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林富寶"
+        "lang:zh-tw": "林富寶"
       },
       "id": "Q50091755",
       "identifiers": [
@@ -353,7 +353,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鍾盛有"
+        "lang:zh-tw": "鍾盛有"
       },
       "id": "Q50091795",
       "identifiers": [
@@ -368,7 +368,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉馨正"
+        "lang:zh-tw": "劉馨正"
       },
       "id": "Q50091835",
       "identifiers": [
@@ -383,7 +383,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李長生"
+        "lang:zh-tw": "李長生"
       },
       "id": "Q50091951",
       "identifiers": [
@@ -398,7 +398,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "方信淵"
+        "lang:zh-tw": "方信淵"
       },
       "id": "Q50091993",
       "identifiers": [
@@ -413,7 +413,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "高閔琳"
+        "lang:zh-tw": "高閔琳"
       },
       "id": "Q50092039",
       "identifiers": [
@@ -428,7 +428,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陸淑美"
+        "lang:zh-tw": "陸淑美"
       },
       "id": "Q50092116",
       "identifiers": [
@@ -443,7 +443,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "翁瑞珠"
+        "lang:zh-tw": "翁瑞珠"
       },
       "id": "Q50092161",
       "identifiers": [
@@ -458,7 +458,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳玫娟"
+        "lang:zh-tw": "陳玫娟"
       },
       "id": "Q50092202",
       "identifiers": [
@@ -473,7 +473,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃石龍"
+        "lang:zh-tw": "黃石龍"
       },
       "id": "Q50092289",
       "identifiers": [
@@ -488,7 +488,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周鍾㴴"
+        "lang:zh-tw": "周鍾㴴"
       },
       "id": "Q50092330",
       "identifiers": [
@@ -503,7 +503,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李眉蓁"
+        "lang:zh-tw": "李眉蓁"
       },
       "id": "Q50092375",
       "identifiers": [
@@ -518,7 +518,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張豐藤"
+        "lang:zh-tw": "張豐藤"
       },
       "id": "Q50092500",
       "identifiers": [
@@ -533,7 +533,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張勝富"
+        "lang:zh-tw": "張勝富"
       },
       "id": "Q50092542",
       "identifiers": [
@@ -548,7 +548,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林芳如"
+        "lang:zh-tw": "林芳如"
       },
       "id": "Q50092587",
       "identifiers": [
@@ -563,7 +563,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "沈英章"
+        "lang:zh-tw": "沈英章"
       },
       "id": "Q50092625",
       "identifiers": [
@@ -578,7 +578,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許慧玉"
+        "lang:zh-tw": "許慧玉"
       },
       "id": "Q50092663",
       "identifiers": [
@@ -593,7 +593,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱俊憲"
+        "lang:zh-tw": "邱俊憲"
       },
       "id": "Q50092699",
       "identifiers": [
@@ -608,7 +608,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "童燕珍"
+        "lang:zh-tw": "童燕珍"
       },
       "id": "Q50092988",
       "identifiers": [
@@ -623,7 +623,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾俊傑"
+        "lang:zh-tw": "曾俊傑"
       },
       "id": "Q50093204",
       "identifiers": [
@@ -638,7 +638,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃香菽"
+        "lang:zh-tw": "黃香菽"
       },
       "id": "Q50093239",
       "identifiers": [
@@ -653,7 +653,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳益政"
+        "lang:zh-tw": "吳益政"
       },
       "id": "Q50093311",
       "identifiers": [
@@ -668,7 +668,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周玲妏"
+        "lang:zh-tw": "周玲妏"
       },
       "id": "Q50093460",
       "identifiers": [
@@ -683,7 +683,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊見福"
+        "lang:zh-tw": "楊見福"
       },
       "id": "Q50093507",
       "identifiers": [
@@ -698,7 +698,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇炎城"
+        "lang:zh-tw": "蘇炎城"
       },
       "id": "Q50093534",
       "identifiers": [
@@ -713,7 +713,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳慧文"
+        "lang:zh-tw": "陳慧文"
       },
       "id": "Q50093558",
       "identifiers": [
@@ -728,7 +728,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳粹鑾"
+        "lang:zh-tw": "陳粹鑾"
       },
       "id": "Q50093667",
       "identifiers": [
@@ -743,7 +743,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉德林"
+        "lang:zh-tw": "劉德林"
       },
       "id": "Q50093713",
       "identifiers": [
@@ -758,7 +758,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅鼎城"
+        "lang:zh-tw": "羅鼎城"
       },
       "id": "Q50093761",
       "identifiers": [
@@ -773,7 +773,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林宛蓉"
+        "lang:zh-tw": "林宛蓉"
       },
       "id": "Q50093890",
       "identifiers": [
@@ -788,7 +788,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳銘賜"
+        "lang:zh-tw": "吳銘賜"
       },
       "id": "Q50093933",
       "identifiers": [
@@ -803,7 +803,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳麗娜"
+        "lang:zh-tw": "陳麗娜"
       },
       "id": "Q50094021",
       "identifiers": [
@@ -818,7 +818,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭光峰"
+        "lang:zh-tw": "鄭光峰"
       },
       "id": "Q50094071",
       "identifiers": [
@@ -833,7 +833,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾麗燕"
+        "lang:zh-tw": "曾麗燕"
       },
       "id": "Q50094116",
       "identifiers": [
@@ -848,7 +848,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李順進"
+        "lang:zh-tw": "李順進"
       },
       "id": "Q50094184",
       "identifiers": [
@@ -863,7 +863,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李雨庭"
+        "lang:zh-tw": "李雨庭"
       },
       "id": "Q50094223",
       "identifiers": [
@@ -878,7 +878,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃天煌"
+        "lang:zh-tw": "黃天煌"
       },
       "id": "Q50094291",
       "identifiers": [
@@ -893,7 +893,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王耀裕"
+        "lang:zh-tw": "王耀裕"
       },
       "id": "Q50094328",
       "identifiers": [
@@ -908,7 +908,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "柯路加Istanbaciban"
+        "lang:zh-tw": "柯路加Istanbaciban"
       },
       "id": "Q50094402",
       "identifiers": [
@@ -923,7 +923,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林民傑"
+        "lang:zh-tw": "林民傑"
       },
       "id": "Q50094446",
       "identifiers": [
@@ -938,7 +938,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "伊斯坦大‧貝雅夫‧正福Istanda‧Paingav"
+        "lang:zh-tw": "伊斯坦大‧貝雅夫‧正福Istanda‧Paingav"
       },
       "id": "Q50094491",
       "identifiers": [
@@ -953,7 +953,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "唐惠美"
+        "lang:zh-tw": "唐惠美"
       },
       "id": "Q50094529",
       "identifiers": [
@@ -968,7 +968,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張漢忠"
+        "lang:zh-tw": "張漢忠"
       },
       "id": "Q50184859",
       "identifiers": [
@@ -983,7 +983,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃柏霖"
+        "lang:zh-tw": "黃柏霖"
       },
       "id": "Q8274108",
       "identifiers": [
@@ -998,7 +998,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林瑩蓉"
+        "lang:zh-tw": "林瑩蓉"
       },
       "id": "Q8349872",
       "identifiers": [
@@ -1013,7 +1013,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顏曉菁"
+        "lang:zh-tw": "顏曉菁"
       },
       "id": "Q8350751",
       "identifiers": [
@@ -1028,7 +1028,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳明澤"
+        "lang:zh-tw": "陳明澤"
       },
       "id": "Q8351145",
       "identifiers": [
@@ -1045,8 +1045,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "高雄市議會",
-        "lang:en_US": "Kaohsiung City Council"
+        "lang:zh-tw": "高雄市議會",
+        "lang:en": "Kaohsiung City Council"
       },
       "id": "Q6366073",
       "classification": "branch",
@@ -1063,8 +1063,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "親民黨",
-        "lang:en_US": "People First Party"
+        "lang:zh-tw": "親民黨",
+        "lang:en": "People First Party"
       },
       "id": "Q1442482",
       "classification": "party",
@@ -1077,8 +1077,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -1091,8 +1091,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "台灣團結聯盟",
-        "lang:en_US": "Taiwan Solidarity Union"
+        "lang:zh-tw": "台灣團結聯盟",
+        "lang:en": "Taiwan Solidarity Union"
       },
       "id": "Q706834",
       "classification": "party",
@@ -1105,8 +1105,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "無黨團結聯盟",
-        "lang:en_US": "Non-Partisan Solidarity Union"
+        "lang:zh-tw": "無黨團結聯盟",
+        "lang:en": "Non-Partisan Solidarity Union"
       },
       "id": "Q718487",
       "classification": "party",
@@ -1119,8 +1119,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -1149,8 +1149,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -1174,8 +1174,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第01選區"
@@ -1198,8 +1198,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第02選區"
@@ -1222,8 +1222,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第03選區"
@@ -1246,8 +1246,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第04選區"
@@ -1270,8 +1270,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第05選區"
@@ -1294,8 +1294,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第06選區"
@@ -1318,8 +1318,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第07選區"
@@ -1342,8 +1342,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第08選區"
@@ -1366,8 +1366,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第09選區"
@@ -1390,8 +1390,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第10選區"
@@ -1414,8 +1414,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第11選區"
@@ -1438,8 +1438,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第12選區"
@@ -1462,8 +1462,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第13選區"
@@ -1486,8 +1486,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第14選區"
@@ -1510,8 +1510,8 @@
         "Q49257749"
       ],
       "type": {
-        "lang:zh_TW": "高雄市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Kaohsiung City"
+        "lang:zh-tw": "高雄市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
         "lang:zh_TW": "高雄市第15選區"
@@ -1534,8 +1534,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -1554,12 +1554,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1571,12 +1571,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1588,12 +1588,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1606,12 +1606,12 @@
       "end_date": "2017-02-16",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1623,12 +1623,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1640,12 +1640,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1657,12 +1657,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1674,12 +1674,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1691,12 +1691,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1708,12 +1708,12 @@
       "start_date": "1994-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1725,12 +1725,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1742,12 +1742,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1759,12 +1759,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1776,12 +1776,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1793,12 +1793,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1809,12 +1809,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1826,12 +1826,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1843,12 +1843,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1860,12 +1860,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1877,12 +1877,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1894,12 +1894,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1911,12 +1911,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1928,12 +1928,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1944,12 +1944,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1961,12 +1961,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1978,12 +1978,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -1995,12 +1995,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2012,12 +2012,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2029,12 +2029,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2046,12 +2046,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2063,12 +2063,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2080,12 +2080,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2097,12 +2097,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2114,12 +2114,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2131,12 +2131,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2148,12 +2148,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2165,12 +2165,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2182,12 +2182,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2199,12 +2199,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2216,12 +2216,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2233,12 +2233,12 @@
       "start_date": "2017-02-16",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2250,12 +2250,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2267,12 +2267,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2284,12 +2284,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2301,12 +2301,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2318,12 +2318,12 @@
       "end_date": "2015-12-08",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2335,12 +2335,12 @@
       "start_date": "2015-12-08",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2352,12 +2352,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2369,12 +2369,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2386,12 +2386,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2403,12 +2403,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2420,12 +2420,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2437,12 +2437,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2454,12 +2454,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2471,12 +2471,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2488,12 +2488,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2505,12 +2505,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2522,12 +2522,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2539,12 +2539,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2556,12 +2556,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2573,12 +2573,12 @@
       "start_date": "2017-01-04",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2590,12 +2590,12 @@
       "end_date": "2017-01-04",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2606,12 +2606,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2623,12 +2623,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2640,12 +2640,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2657,12 +2657,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2674,12 +2674,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2691,12 +2691,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     },
     {
@@ -2708,12 +2708,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49257749",
       "role": {
-        "lang:zh_TW": "高雄市議員"
+        "lang:zh-tw": "高雄市議員"
       }
     }
   ]

--- a/legislative/Q715869/Q22083907/popolo-m17n.json
+++ b/legislative/Q715869/Q22083907/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "呂玉玲"
+        "lang:zh-tw": "呂玉玲"
       },
       "id": "Q10919979",
       "identifiers": [
@@ -17,8 +17,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃國昌",
-        "lang:en_US": "Huang Kuo-chang"
+        "lang:zh-tw": "黃國昌",
+        "lang:en": "Huang Kuo-chang"
       },
       "id": "Q15899237",
       "identifiers": [
@@ -36,8 +36,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡培慧",
-        "lang:en_US": "Frida Tsai"
+        "lang:zh-tw": "蔡培慧",
+        "lang:en": "Frida Tsai"
       },
       "id": "Q15901623",
       "identifiers": [
@@ -52,8 +52,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顧立雄",
-        "lang:en_US": "Wellington Koo"
+        "lang:zh-tw": "顧立雄",
+        "lang:en": "Wellington Koo"
       },
       "id": "Q15909081",
       "identifiers": [
@@ -68,8 +68,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔣萬安",
-        "lang:en_US": "Chiang Wan-an"
+        "lang:zh-tw": "蔣萬安",
+        "lang:en": "Chiang Wan-an"
       },
       "id": "Q15920021",
       "identifiers": [
@@ -84,7 +84,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳怡潔"
+        "lang:zh-tw": "陳怡潔"
       },
       "id": "Q15930216",
       "identifiers": [
@@ -99,8 +99,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾銘宗",
-        "lang:en_US": "Tseng Ming-chung"
+        "lang:zh-tw": "曾銘宗",
+        "lang:en": "Tseng Ming-chung"
       },
       "id": "Q16193401",
       "identifiers": [
@@ -115,8 +115,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "呂孫綾",
-        "lang:en_US": "Lu Sun-ling"
+        "lang:zh-tw": "呂孫綾",
+        "lang:en": "Lu Sun-ling"
       },
       "id": "Q16928868",
       "identifiers": [
@@ -131,8 +131,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭天財Sra‧Kacaw",
-        "lang:en_US": "Zheng Tiancai"
+        "lang:zh-tw": "鄭天財Sra‧Kacaw",
+        "lang:en": "Zheng Tiancai"
       },
       "id": "Q17027222",
       "identifiers": [
@@ -147,8 +147,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳焜裕",
-        "lang:en_US": "Wu, Kuen-Yuh"
+        "lang:zh-tw": "吳焜裕",
+        "lang:en": "Wu, Kuen-Yuh"
       },
       "id": "Q18415702",
       "identifiers": [
@@ -163,8 +163,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許淑華",
-        "lang:en_US": "Hsu Shu-hua"
+        "lang:zh-tw": "許淑華",
+        "lang:en": "Hsu Shu-hua"
       },
       "id": "Q18659220",
       "identifiers": [
@@ -179,8 +179,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃國書",
-        "lang:en_US": "Huang Kuo-shu"
+        "lang:zh-tw": "黃國書",
+        "lang:en": "Huang Kuo-shu"
       },
       "id": "Q19058548",
       "identifiers": [
@@ -195,8 +195,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳素月",
-        "lang:en_US": "Chen Su-yueh"
+        "lang:zh-tw": "陳素月",
+        "lang:en": "Chen Su-yueh"
       },
       "id": "Q19653988",
       "identifiers": [
@@ -211,7 +211,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳賴素美"
+        "lang:zh-tw": "陳賴素美"
       },
       "id": "Q19825208",
       "identifiers": [
@@ -226,7 +226,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐志榮"
+        "lang:zh-tw": "徐志榮"
       },
       "id": "Q19825322",
       "identifiers": [
@@ -241,8 +241,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林俊憲",
-        "lang:en_US": "Lin Chun-hsien"
+        "lang:zh-tw": "林俊憲",
+        "lang:en": "Lin Chun-hsien"
       },
       "id": "Q19825673",
       "identifiers": [
@@ -257,8 +257,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇巧慧",
-        "lang:en_US": "Su Chiao-hui"
+        "lang:zh-tw": "蘇巧慧",
+        "lang:en": "Su Chiao-hui"
       },
       "id": "Q19825781",
       "identifiers": [
@@ -273,7 +273,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴瑞隆"
+        "lang:zh-tw": "賴瑞隆"
       },
       "id": "Q19825797",
       "identifiers": [
@@ -288,7 +288,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪宗熠"
+        "lang:zh-tw": "洪宗熠"
       },
       "id": "Q19849340",
       "identifiers": [
@@ -303,8 +303,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪慈庸",
-        "lang:en_US": "Hung Tzu-yung"
+        "lang:zh-tw": "洪慈庸",
+        "lang:en": "Hung Tzu-yung"
       },
       "id": "Q19849402",
       "identifiers": [
@@ -322,8 +322,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳琪銘",
-        "lang:en_US": "Wu Chi-ming"
+        "lang:zh-tw": "吳琪銘",
+        "lang:en": "Wu Chi-ming"
       },
       "id": "Q19849414",
       "identifiers": [
@@ -338,7 +338,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李彥秀"
+        "lang:zh-tw": "李彥秀"
       },
       "id": "Q20063502",
       "identifiers": [
@@ -353,8 +353,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "高潞‧以用‧巴魕剌Kawlo‧Iyun‧Pacidal",
-        "lang:en_US": "Kawlo Iyun Pacidal"
+        "lang:zh-tw": "高潞‧以用‧巴魕剌Kawlo‧Iyun‧Pacidal",
+        "lang:en": "Kawlo Iyun Pacidal"
       },
       "id": "Q21652173",
       "identifiers": [
@@ -369,8 +369,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林麗蟬",
-        "lang:en_US": "Lin Li-chan"
+        "lang:zh-tw": "林麗蟬",
+        "lang:en": "Lin Li-chan"
       },
       "id": "Q22093639",
       "identifiers": [
@@ -385,8 +385,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "谷辣斯‧尤達卡Kolasyotaka",
-        "lang:en_US": "Kolas Yotaka"
+        "lang:zh-tw": "谷辣斯‧尤達卡Kolasyotaka",
+        "lang:en": "Kolas Yotaka"
       },
       "id": "Q22099954",
       "identifiers": [
@@ -401,8 +401,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "趙正宇",
-        "lang:en_US": "Chao Cheng-yu"
+        "lang:zh-tw": "趙正宇",
+        "lang:en": "Chao Cheng-yu"
       },
       "id": "Q22100240",
       "identifiers": [
@@ -417,8 +417,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "余宛如",
-        "lang:en_US": "Karen Yu"
+        "lang:zh-tw": "余宛如",
+        "lang:en": "Karen Yu"
       },
       "id": "Q22773998",
       "identifiers": [
@@ -433,7 +433,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳玉琴"
+        "lang:zh-tw": "吳玉琴"
       },
       "id": "Q22774114",
       "identifiers": [
@@ -448,8 +448,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周春米",
-        "lang:en_US": "Chou,Chun-Mi"
+        "lang:zh-tw": "周春米",
+        "lang:en": "Chou,Chun-Mi"
       },
       "id": "Q22774121",
       "identifiers": [
@@ -464,8 +464,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林靜儀",
-        "lang:en_US": "Lin Ching-yi"
+        "lang:zh-tw": "林靜儀",
+        "lang:en": "Lin Ching-yi"
       },
       "id": "Q22774129",
       "identifiers": [
@@ -480,7 +480,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鍾孔炤"
+        "lang:zh-tw": "鍾孔炤"
       },
       "id": "Q22774142",
       "identifiers": [
@@ -495,8 +495,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳曼麗",
-        "lang:en_US": "Chen Man-li"
+        "lang:zh-tw": "陳曼麗",
+        "lang:en": "Chen Man-li"
       },
       "id": "Q22774153",
       "identifiers": [
@@ -511,7 +511,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊鎮浯"
+        "lang:zh-tw": "楊鎮浯"
       },
       "id": "Q22774355",
       "identifiers": [
@@ -526,8 +526,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許毓仁",
-        "lang:en_US": "Hsu Yu-jen"
+        "lang:zh-tw": "許毓仁",
+        "lang:en": "Hsu Yu-jen"
       },
       "id": "Q23927581",
       "identifiers": [
@@ -542,8 +542,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳宜民",
-        "lang:en_US": "Chen Yi-Ming"
+        "lang:zh-tw": "陳宜民",
+        "lang:en": "Chen Yi-Ming"
       },
       "id": "Q24839448",
       "identifiers": [
@@ -558,7 +558,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李麗芬"
+        "lang:zh-tw": "李麗芬"
       },
       "id": "Q24840132",
       "identifiers": [
@@ -573,8 +573,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱泰源",
-        "lang:en_US": "Tai-Yuan Chiu"
+        "lang:zh-tw": "邱泰源",
+        "lang:en": "Tai-Yuan Chiu"
       },
       "id": "Q28413232",
       "identifiers": [
@@ -589,8 +589,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "柯志恩",
-        "lang:en_US": "Chih-En Ko"
+        "lang:zh-tw": "柯志恩",
+        "lang:en": "Chih-En Ko"
       },
       "id": "Q28416376",
       "identifiers": [
@@ -605,8 +605,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐榛蔚",
-        "lang:en_US": "Chen-Wei Hsu"
+        "lang:zh-tw": "徐榛蔚",
+        "lang:en": "Chen-Wei Hsu"
       },
       "id": "Q28418899",
       "identifiers": [
@@ -621,8 +621,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周陳秀霞",
-        "lang:en_US": "Hsiu-Hsia Chou Chen"
+        "lang:zh-tw": "周陳秀霞",
+        "lang:en": "Hsiu-Hsia Chou Chen"
       },
       "id": "Q28522108",
       "identifiers": [
@@ -637,8 +637,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "管碧玲",
-        "lang:en_US": "Bi-ling Kuan"
+        "lang:zh-tw": "管碧玲",
+        "lang:en": "Bi-ling Kuan"
       },
       "id": "Q3846662",
       "identifiers": [
@@ -653,8 +653,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳其邁",
-        "lang:en_US": "Chen Chi-mai"
+        "lang:zh-tw": "陳其邁",
+        "lang:en": "Chen Chi-mai"
       },
       "id": "Q5090717",
       "identifiers": [
@@ -669,8 +669,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳明文",
-        "lang:en_US": "Chen Ming-Wen"
+        "lang:zh-tw": "陳明文",
+        "lang:en": "Chen Ming-Wen"
       },
       "id": "Q5090859",
       "identifiers": [
@@ -685,8 +685,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "柯建銘",
-        "lang:en_US": "Ker Chien-ming"
+        "lang:zh-tw": "柯建銘",
+        "lang:en": "Ker Chien-ming"
       },
       "id": "Q6393270",
       "identifiers": [
@@ -701,8 +701,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李應元",
-        "lang:en_US": "Lee Ying-yuan"
+        "lang:zh-tw": "李應元",
+        "lang:en": "Lee Ying-yuan"
       },
       "id": "Q6515593",
       "identifiers": [
@@ -717,8 +717,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉世芳",
-        "lang:en_US": "Liu Shih-fang"
+        "lang:zh-tw": "劉世芳",
+        "lang:en": "Liu Shih-fang"
       },
       "id": "Q6653712",
       "identifiers": [
@@ -733,8 +733,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "高金素梅",
-        "lang:en_US": "Kao Chin Su-mei"
+        "lang:zh-tw": "高金素梅",
+        "lang:en": "Kao Chin Su-mei"
       },
       "id": "Q697862",
       "identifiers": [
@@ -749,8 +749,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蕭美琴",
-        "lang:en_US": "Bi-khim Hsiao"
+        "lang:zh-tw": "蕭美琴",
+        "lang:en": "Bi-khim Hsiao"
       },
       "id": "Q700752",
       "identifiers": [
@@ -765,8 +765,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇嘉全",
-        "lang:en_US": "Su Chia-chyuan"
+        "lang:zh-tw": "蘇嘉全",
+        "lang:en": "Su Chia-chyuan"
       },
       "id": "Q700774",
       "identifiers": [
@@ -781,8 +781,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王金平",
-        "lang:en_US": "Wang Jin-pyng"
+        "lang:zh-tw": "王金平",
+        "lang:en": "Wang Jin-pyng"
       },
       "id": "Q707601",
       "identifiers": [
@@ -797,8 +797,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王定宇",
-        "lang:en_US": "Wang Ding-yu"
+        "lang:zh-tw": "王定宇",
+        "lang:en": "Wang Ding-yu"
       },
       "id": "Q709508",
       "identifiers": [
@@ -813,8 +813,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳瑩",
-        "lang:en_US": "Chen Ying"
+        "lang:zh-tw": "陳瑩",
+        "lang:en": "Chen Ying"
       },
       "id": "Q7198343",
       "identifiers": [
@@ -829,8 +829,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃昭順",
-        "lang:en_US": "Chao-shun Huang"
+        "lang:zh-tw": "黃昭順",
+        "lang:en": "Chao-shun Huang"
       },
       "id": "Q8270063",
       "identifiers": [
@@ -845,8 +845,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳學聖",
-        "lang:en_US": "Apollo Chen"
+        "lang:zh-tw": "陳學聖",
+        "lang:en": "Apollo Chen"
       },
       "id": "Q8273045",
       "identifiers": [
@@ -861,8 +861,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳雪生",
-        "lang:en_US": "Chen Hsueh-sheng"
+        "lang:zh-tw": "陳雪生",
+        "lang:en": "Chen Hsueh-sheng"
       },
       "id": "Q8273082",
       "identifiers": [
@@ -880,7 +880,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張麗善"
+        "lang:zh-tw": "張麗善"
       },
       "id": "Q8273132",
       "identifiers": [
@@ -895,8 +895,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳超明",
-        "lang:en_US": "Chao-ming Chen"
+        "lang:zh-tw": "陳超明",
+        "lang:en": "Chao-ming Chen"
       },
       "id": "Q8273248",
       "identifiers": [
@@ -911,8 +911,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔣乃辛",
-        "lang:en_US": "Chiang Nai-shin"
+        "lang:zh-tw": "蔣乃辛",
+        "lang:en": "Chiang Nai-shin"
       },
       "id": "Q8274144",
       "identifiers": [
@@ -927,8 +927,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "簡東明",
-        "lang:en_US": "Chien Tung-ming"
+        "lang:zh-tw": "簡東明",
+        "lang:en": "Chien Tung-ming"
       },
       "id": "Q8274185",
       "identifiers": [
@@ -943,8 +943,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "孔文吉",
-        "lang:en_US": "Kung Wen-chi"
+        "lang:zh-tw": "孔文吉",
+        "lang:en": "Kung Wen-chi"
       },
       "id": "Q8274261",
       "identifiers": [
@@ -959,8 +959,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "廖國棟",
-        "lang:en_US": "Liao Kuo-tung"
+        "lang:zh-tw": "廖國棟",
+        "lang:en": "Liao Kuo-tung"
       },
       "id": "Q8274398",
       "identifiers": [
@@ -975,7 +975,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "盧秀燕"
+        "lang:zh-tw": "盧秀燕"
       },
       "id": "Q8274707",
       "identifiers": [
@@ -990,8 +990,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李鴻鈞",
-        "lang:en_US": "Lee Hong-cuan"
+        "lang:zh-tw": "李鴻鈞",
+        "lang:en": "Lee Hong-cuan"
       },
       "id": "Q8275115",
       "identifiers": [
@@ -1006,7 +1006,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林德福"
+        "lang:zh-tw": "林德福"
       },
       "id": "Q8275203",
       "identifiers": [
@@ -1021,7 +1021,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅明才"
+        "lang:zh-tw": "羅明才"
       },
       "id": "Q8275466",
       "identifiers": [
@@ -1036,8 +1036,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴士葆",
-        "lang:en_US": "Lai Shyh-bao"
+        "lang:zh-tw": "賴士葆",
+        "lang:en": "Lai Shyh-bao"
       },
       "id": "Q8275493",
       "identifiers": [
@@ -1052,8 +1052,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳志揚",
-        "lang:en_US": "John Wu"
+        "lang:zh-tw": "吳志揚",
+        "lang:en": "John Wu"
       },
       "id": "Q8277261",
       "identifiers": [
@@ -1068,8 +1068,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顏寬恒",
-        "lang:en_US": "Yen Kuan-heng"
+        "lang:zh-tw": "顏寬恒",
+        "lang:en": "Yen Kuan-heng"
       },
       "id": "Q8278820",
       "identifiers": [
@@ -1084,8 +1084,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "江啟臣",
-        "lang:en_US": "Johnny Chiang"
+        "lang:zh-tw": "江啟臣",
+        "lang:en": "Johnny Chiang"
       },
       "id": "Q8279603",
       "identifiers": [
@@ -1100,8 +1100,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王惠美",
-        "lang:en_US": "Wang Huei-mei"
+        "lang:zh-tw": "王惠美",
+        "lang:en": "Wang Huei-mei"
       },
       "id": "Q8279684",
       "identifiers": [
@@ -1116,7 +1116,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王育敏"
+        "lang:zh-tw": "王育敏"
       },
       "id": "Q8279711",
       "identifiers": [
@@ -1131,8 +1131,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "馬文君",
-        "lang:en_US": "Ma Wen-chun"
+        "lang:zh-tw": "馬文君",
+        "lang:en": "Ma Wen-chun"
       },
       "id": "Q8279858",
       "identifiers": [
@@ -1147,8 +1147,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張廖萬堅",
-        "lang:en_US": "Chang Liao Wan-chien"
+        "lang:zh-tw": "張廖萬堅",
+        "lang:en": "Chang Liao Wan-chien"
       },
       "id": "Q8347319",
       "identifiers": [
@@ -1163,8 +1163,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李俊俋",
-        "lang:en_US": "Lee Chun-yi"
+        "lang:zh-tw": "李俊俋",
+        "lang:en": "Lee Chun-yi"
       },
       "id": "Q8347574",
       "identifiers": [
@@ -1179,7 +1179,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡適應"
+        "lang:zh-tw": "蔡適應"
       },
       "id": "Q8347638",
       "identifiers": [
@@ -1194,7 +1194,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "趙天麟"
+        "lang:zh-tw": "趙天麟"
       },
       "id": "Q8347665",
       "identifiers": [
@@ -1209,8 +1209,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱志偉",
-        "lang:en_US": "Chiu Chi-wei"
+        "lang:zh-tw": "邱志偉",
+        "lang:en": "Chiu Chi-wei"
       },
       "id": "Q8347718",
       "identifiers": [
@@ -1225,8 +1225,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱議瑩",
-        "lang:en_US": "Chiu Yi-ying"
+        "lang:zh-tw": "邱議瑩",
+        "lang:en": "Chiu Yi-ying"
       },
       "id": "Q8347775",
       "identifiers": [
@@ -1241,8 +1241,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳亭妃",
-        "lang:en_US": "Chen Ting-fei"
+        "lang:zh-tw": "陳亭妃",
+        "lang:en": "Chen Ting-fei"
       },
       "id": "Q8347820",
       "identifiers": [
@@ -1257,8 +1257,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳歐珀",
-        "lang:en_US": "Chen Ou-po"
+        "lang:zh-tw": "陳歐珀",
+        "lang:en": "Chen Ou-po"
       },
       "id": "Q8347997",
       "identifiers": [
@@ -1273,8 +1273,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭正亮",
-        "lang:en_US": "Julian Kuo"
+        "lang:zh-tw": "郭正亮",
+        "lang:en": "Julian Kuo"
       },
       "id": "Q8348328",
       "identifiers": [
@@ -1289,8 +1289,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "高志鵬",
-        "lang:en_US": "Gao Jyh-peng"
+        "lang:zh-tw": "高志鵬",
+        "lang:en": "Gao Jyh-peng"
       },
       "id": "Q8348463",
       "identifiers": [
@@ -1305,8 +1305,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃偉哲",
-        "lang:en_US": "Huang Wei-cher"
+        "lang:zh-tw": "黃偉哲",
+        "lang:en": "Huang Wei-cher"
       },
       "id": "Q8348653",
       "identifiers": [
@@ -1321,8 +1321,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何欣純",
-        "lang:en_US": "Ho Hsin-chun"
+        "lang:zh-tw": "何欣純",
+        "lang:en": "Ho Hsin-chun"
       },
       "id": "Q8348788",
       "identifiers": [
@@ -1337,7 +1337,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐國勇"
+        "lang:zh-tw": "徐國勇"
       },
       "id": "Q8348841",
       "identifiers": [
@@ -1352,8 +1352,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許智傑",
-        "lang:en_US": "Hsu Chih-chieh"
+        "lang:zh-tw": "許智傑",
+        "lang:en": "Hsu Chih-chieh"
       },
       "id": "Q8349077",
       "identifiers": [
@@ -1368,8 +1368,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃秀芳",
-        "lang:en_US": "Huang Hsiu-fang"
+        "lang:zh-tw": "黃秀芳",
+        "lang:en": "Huang Hsiu-fang"
       },
       "id": "Q8349282",
       "identifiers": [
@@ -1384,7 +1384,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭寶清"
+        "lang:zh-tw": "鄭寶清"
       },
       "id": "Q8349451",
       "identifiers": [
@@ -1399,8 +1399,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "羅致政",
-        "lang:en_US": "Lo Chih-cheng"
+        "lang:zh-tw": "羅致政",
+        "lang:en": "Lo Chih-cheng"
       },
       "id": "Q8349613",
       "identifiers": [
@@ -1415,8 +1415,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉建國",
-        "lang:en_US": "Liu Chien-kuo"
+        "lang:zh-tw": "劉建國",
+        "lang:en": "Liu Chien-kuo"
       },
       "id": "Q8349646",
       "identifiers": [
@@ -1431,8 +1431,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉櫂豪",
-        "lang:en_US": "Chao-hao Liu"
+        "lang:zh-tw": "劉櫂豪",
+        "lang:en": "Chao-hao Liu"
       },
       "id": "Q8349660",
       "identifiers": [
@@ -1447,8 +1447,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李昆澤",
-        "lang:en_US": "Lee Kun-tse"
+        "lang:zh-tw": "李昆澤",
+        "lang:en": "Lee Kun-tse"
       },
       "id": "Q8349723",
       "identifiers": [
@@ -1463,8 +1463,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林岱樺",
-        "lang:en_US": "Lin Tai-hua"
+        "lang:zh-tw": "林岱樺",
+        "lang:en": "Lin Tai-hua"
       },
       "id": "Q8349768",
       "identifiers": [
@@ -1479,8 +1479,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇治芬",
-        "lang:en_US": "Su Chih-fen"
+        "lang:zh-tw": "蘇治芬",
+        "lang:en": "Su Chih-fen"
       },
       "id": "Q8350160",
       "identifiers": [
@@ -1495,8 +1495,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "施義芳",
-        "lang:en_US": "Shih Yi-fang"
+        "lang:zh-tw": "施義芳",
+        "lang:en": "Shih Yi-fang"
       },
       "id": "Q8350171",
       "identifiers": [
@@ -1511,7 +1511,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蘇震清"
+        "lang:zh-tw": "蘇震清"
       },
       "id": "Q8350223",
       "identifiers": [
@@ -1526,8 +1526,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡其昌",
-        "lang:en_US": "Tsai Chi-chang"
+        "lang:zh-tw": "蔡其昌",
+        "lang:en": "Tsai Chi-chang"
       },
       "id": "Q8350279",
       "identifiers": [
@@ -1542,7 +1542,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡易餘"
+        "lang:zh-tw": "蔡易餘"
       },
       "id": "Q8350388",
       "identifiers": [
@@ -1557,8 +1557,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳思瑤",
-        "lang:en_US": "Rosalia Wu"
+        "lang:zh-tw": "吳思瑤",
+        "lang:en": "Rosalia Wu"
       },
       "id": "Q8350455",
       "identifiers": [
@@ -1573,7 +1573,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳秉叡"
+        "lang:zh-tw": "吳秉叡"
       },
       "id": "Q8350478",
       "identifiers": [
@@ -1588,8 +1588,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王榮璋",
-        "lang:en_US": "Wang Jung-chang"
+        "lang:zh-tw": "王榮璋",
+        "lang:en": "Wang Jung-chang"
       },
       "id": "Q8350543",
       "identifiers": [
@@ -1604,8 +1604,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "姚文智",
-        "lang:en_US": "Pasuya Yao"
+        "lang:zh-tw": "姚文智",
+        "lang:en": "Pasuya Yao"
       },
       "id": "Q8350665",
       "identifiers": [
@@ -1620,8 +1620,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊曜",
-        "lang:en_US": "Yang Yao"
+        "lang:zh-tw": "楊曜",
+        "lang:en": "Yang Yao"
       },
       "id": "Q8350686",
       "identifiers": [
@@ -1636,8 +1636,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "葉宜津",
-        "lang:en_US": "Yeh Yi-jin"
+        "lang:zh-tw": "葉宜津",
+        "lang:en": "Yeh Yi-jin"
       },
       "id": "Q8350727",
       "identifiers": [
@@ -1652,8 +1652,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張宏陸",
-        "lang:en_US": "Chang Hung-lu"
+        "lang:zh-tw": "張宏陸",
+        "lang:en": "Chang Hung-lu"
       },
       "id": "Q8350806",
       "identifiers": [
@@ -1668,7 +1668,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "江永昌"
+        "lang:zh-tw": "江永昌"
       },
       "id": "Q8350960",
       "identifiers": [
@@ -1683,8 +1683,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "莊瑞雄",
-        "lang:en_US": "Chuang Jui-hsiung"
+        "lang:zh-tw": "莊瑞雄",
+        "lang:en": "Chuang Jui-hsiung"
       },
       "id": "Q8351019",
       "identifiers": [
@@ -1699,8 +1699,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭麗君",
-        "lang:en_US": "Cheng Li-chun"
+        "lang:zh-tw": "鄭麗君",
+        "lang:en": "Cheng Li-chun"
       },
       "id": "Q8351107",
       "identifiers": [
@@ -1715,7 +1715,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林為洲"
+        "lang:zh-tw": "林為洲"
       },
       "id": "Q8351569",
       "identifiers": [
@@ -1730,8 +1730,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鍾佳濱",
-        "lang:en_US": "Chung Chia-pin"
+        "lang:zh-tw": "鍾佳濱",
+        "lang:en": "Chung Chia-pin"
       },
       "id": "Q8351814",
       "identifiers": [
@@ -1746,8 +1746,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "段宜康",
-        "lang:en_US": "Tuan Yi-kang"
+        "lang:zh-tw": "段宜康",
+        "lang:en": "Tuan Yi-kang"
       },
       "id": "Q8357056",
       "identifiers": [
@@ -1762,8 +1762,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鄭運鵬",
-        "lang:en_US": "Cheng Yun-peng"
+        "lang:zh-tw": "鄭運鵬",
+        "lang:en": "Cheng Yun-peng"
       },
       "id": "Q8357125",
       "identifiers": [
@@ -1778,8 +1778,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林淑芬",
-        "lang:en_US": "Lin Shu-fen"
+        "lang:zh-tw": "林淑芬",
+        "lang:en": "Lin Shu-fen"
       },
       "id": "Q8357162",
       "identifiers": [
@@ -1794,8 +1794,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐永明",
-        "lang:en_US": "Hsu Yung-ming"
+        "lang:zh-tw": "徐永明",
+        "lang:en": "Hsu Yung-ming"
       },
       "id": "Q8967661",
       "identifiers": [
@@ -1810,8 +1810,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "尤美女",
-        "lang:en_US": "Yu Mei-nu"
+        "lang:zh-tw": "尤美女",
+        "lang:en": "Yu Mei-nu"
       },
       "id": "Q9130647",
       "identifiers": [
@@ -1826,8 +1826,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林昶佐",
-        "lang:en_US": "Freddy Lim"
+        "lang:zh-tw": "林昶佐",
+        "lang:en": "Freddy Lim"
       },
       "id": "Q9292454",
       "identifiers": [
@@ -1845,8 +1845,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "費鴻泰",
-        "lang:en_US": "Fai Hungtai"
+        "lang:zh-tw": "費鴻泰",
+        "lang:en": "Fai Hungtai"
       },
       "id": "Q9346217",
       "identifiers": [
@@ -1863,8 +1863,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "立法院",
-        "lang:en_US": "Legislative Yuan"
+        "lang:zh-tw": "立法院",
+        "lang:en": "Legislative Yuan"
       },
       "id": "Q715869",
       "classification": "branch",
@@ -1881,8 +1881,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "親民黨",
-        "lang:en_US": "People First Party"
+        "lang:zh-tw": "親民黨",
+        "lang:en": "People First Party"
       },
       "id": "Q1442482",
       "classification": "party",
@@ -1895,8 +1895,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "時代力量",
-        "lang:en_US": "New Power Party"
+        "lang:zh-tw": "時代力量",
+        "lang:en": "New Power Party"
       },
       "id": "Q19825637",
       "classification": "party",
@@ -1909,8 +1909,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -1923,8 +1923,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "無黨籍政治人物",
-        "lang:en_US": "independent politician"
+        "lang:zh-tw": "無黨籍政治人物",
+        "lang:en": "independent politician"
       },
       "id": "Q327591",
       "classification": "party",
@@ -1937,8 +1937,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "無黨團結聯盟",
-        "lang:en_US": "Non-Partisan Solidarity Union"
+        "lang:zh-tw": "無黨團結聯盟",
+        "lang:en": "Non-Partisan Solidarity Union"
       },
       "id": "Q718487",
       "classification": "party",
@@ -1951,8 +1951,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -1981,8 +1981,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "南投縣第二選舉區"
@@ -2005,8 +2005,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "嘉義市選舉區"
@@ -2029,8 +2029,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "宜蘭縣選舉區"
@@ -2053,8 +2053,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "屏東縣第一選舉區"
@@ -2077,8 +2077,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新竹市選舉區"
@@ -2101,8 +2101,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新竹縣選舉區"
@@ -2125,8 +2125,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "桃園市第一選舉區"
@@ -2149,8 +2149,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "桃園市第三選舉區"
@@ -2173,8 +2173,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "桃園市第二選舉區"
@@ -2197,8 +2197,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "桃園市第五選舉區"
@@ -2221,8 +2221,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "桃園市第六選舉區"
@@ -2245,8 +2245,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "桃園市第四選舉區"
@@ -2269,8 +2269,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taoyuan City",
@@ -2294,8 +2294,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Changhua County",
@@ -2319,8 +2319,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -2344,8 +2344,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺北市第一選舉區"
@@ -2368,8 +2368,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yunlin County",
@@ -2393,8 +2393,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺中市第四選舉區"
@@ -2417,8 +2417,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺中市第一選舉區"
@@ -2441,8 +2441,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺中市第二選舉區"
@@ -2465,8 +2465,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺中市第三選舉區"
@@ -2489,8 +2489,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "苗栗縣第一選舉區"
@@ -2513,8 +2513,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "苗栗縣第二選舉區"
@@ -2537,8 +2537,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺北市第四選舉區"
@@ -2561,8 +2561,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺南市第一選舉區"
@@ -2585,8 +2585,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Chiayi County",
@@ -2610,8 +2610,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺北市第七選舉區"
@@ -2634,8 +2634,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺北市第三選舉區"
@@ -2658,8 +2658,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺北市第二選舉區"
@@ -2682,8 +2682,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺北市第五選舉區"
@@ -2706,8 +2706,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺北市第八選舉區"
@@ -2730,8 +2730,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺北市第六選舉區"
@@ -2754,8 +2754,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺南市第五選舉區"
@@ -2778,8 +2778,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第一選舉區"
@@ -2802,8 +2802,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第七選舉區"
@@ -2826,8 +2826,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第三選舉區"
@@ -2850,8 +2850,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第九選舉區"
@@ -2874,8 +2874,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第五選舉區"
@@ -2898,8 +2898,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第六選舉區"
@@ -2922,8 +2922,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第十一選舉區"
@@ -2946,8 +2946,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第十二選舉區"
@@ -2970,8 +2970,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第十選舉區"
@@ -2994,8 +2994,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第四選舉區"
@@ -3018,8 +3018,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺中市第七選舉區"
@@ -3042,8 +3042,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺中市第五選舉區"
@@ -3066,8 +3066,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺中市第八選舉區"
@@ -3090,8 +3090,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺中市第六選舉區"
@@ -3114,8 +3114,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺南市第三選舉區"
@@ -3138,8 +3138,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺南市第四選舉區"
@@ -3162,8 +3162,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "高雄市第一選舉區"
@@ -3186,8 +3186,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "高雄市第七選舉區"
@@ -3210,8 +3210,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "高雄市第三選舉區"
@@ -3234,8 +3234,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "高雄市第九選舉區"
@@ -3258,8 +3258,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "高雄市第二選舉區"
@@ -3282,8 +3282,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "高雄市第五選舉區"
@@ -3306,8 +3306,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "高雄市第八選舉區"
@@ -3330,8 +3330,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "高雄市第六選舉區"
@@ -3354,8 +3354,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "高雄市第四選舉區"
@@ -3378,8 +3378,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺南市第二選舉區"
@@ -3402,8 +3402,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "嘉義縣第一選舉區"
@@ -3426,8 +3426,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "嘉義縣第二選舉區"
@@ -3450,8 +3450,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "基隆市選舉區"
@@ -3474,8 +3474,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "屏東縣第三選舉區"
@@ -3498,8 +3498,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "屏東縣第二選舉區"
@@ -3522,8 +3522,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "彰化縣第一選舉區"
@@ -3546,8 +3546,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "彰化縣第二選舉區"
@@ -3570,8 +3570,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "彰化縣第三選舉區"
@@ -3594,8 +3594,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "彰化縣第四選舉區"
@@ -3618,8 +3618,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第二選舉區"
@@ -3642,8 +3642,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "新北市第八選舉區"
@@ -3666,8 +3666,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "臺東縣選舉區"
@@ -3690,8 +3690,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "花蓮縣選舉區"
@@ -3714,8 +3714,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "澎湖縣選舉區"
@@ -3738,8 +3738,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "雲林縣第二選舉區"
@@ -3762,8 +3762,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Kaohsiung City",
@@ -3787,8 +3787,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -3812,8 +3812,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "南投縣第一選舉區"
@@ -3836,8 +3836,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "連江縣選舉區"
@@ -3860,8 +3860,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "金門縣選舉區"
@@ -3884,8 +3884,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "區域立法委員選區",
-        "lang:en_US": "Taiwan legislative election regional district"
+        "lang:zh-tw": "區域立法委員選區",
+        "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
         "lang:zh_TW": "雲林縣第一選舉區"
@@ -3908,8 +3908,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Pingtung County",
@@ -3933,8 +3933,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Penghu County",
@@ -3958,8 +3958,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "選區",
-        "lang:en_US": "constituency"
+        "lang:zh-tw": "選區",
+        "lang:en": "constituency"
       },
       "name": {
         "lang:en_US": "Lowland Aborigine district of national legislators electoral area",
@@ -3983,8 +3983,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "選區",
-        "lang:en_US": "constituency"
+        "lang:zh-tw": "選區",
+        "lang:en": "constituency"
       },
       "name": {
         "lang:en_US": "Highland Aborigine district of national legislators electoral area",
@@ -4008,8 +4008,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Yilan County",
@@ -4033,8 +4033,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "New Taipei City",
@@ -4058,8 +4058,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taichung City",
@@ -4083,8 +4083,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hualien County",
@@ -4108,8 +4108,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Kinmen County",
@@ -4133,8 +4133,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Lienchiang County",
@@ -4158,8 +4158,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Taitung County",
@@ -4183,8 +4183,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Hsinchu City",
@@ -4208,8 +4208,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Chiayi City",
@@ -4233,8 +4233,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "市",
-        "lang:en_US": "provincial city"
+        "lang:zh-tw": "市",
+        "lang:en": "provincial city"
       },
       "name": {
         "lang:en_US": "Keelung City",
@@ -4258,8 +4258,8 @@
         "Q6310593"
       ],
       "type": {
-        "lang:zh_TW": "選區",
-        "lang:en_US": "constituency"
+        "lang:zh-tw": "選區",
+        "lang:en": "constituency"
       },
       "name": {
         "lang:en_US": "Proportional Representation in national legislative election",
@@ -4283,8 +4283,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Miaoli County",
@@ -4308,8 +4308,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Hsinchu County",
@@ -4333,8 +4333,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "縣",
-        "lang:en_US": "county of Taiwan"
+        "lang:zh-tw": "縣",
+        "lang:en": "county of Taiwan"
       },
       "name": {
         "lang:en_US": "Nantou County",
@@ -4358,8 +4358,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -4378,13 +4378,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4396,13 +4396,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4414,13 +4414,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4433,13 +4433,13 @@
       "end_date": "2016-08-31",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4451,13 +4451,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4469,13 +4469,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4487,13 +4487,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4505,13 +4505,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4523,13 +4523,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4541,13 +4541,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4559,13 +4559,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4577,13 +4577,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4595,13 +4595,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4613,13 +4613,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4631,13 +4631,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4649,13 +4649,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4667,13 +4667,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4685,13 +4685,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4703,13 +4703,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4721,13 +4721,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4739,13 +4739,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4757,13 +4757,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4775,13 +4775,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4793,13 +4793,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4811,13 +4811,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4829,13 +4829,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4847,13 +4847,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4865,13 +4865,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4883,13 +4883,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4901,13 +4901,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4919,13 +4919,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4937,13 +4937,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4955,13 +4955,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4973,13 +4973,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -4991,13 +4991,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5009,13 +5009,13 @@
       "start_date": "2016-05-26",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5027,13 +5027,13 @@
       "start_date": "2016-10-04",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5045,13 +5045,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5063,13 +5063,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5081,13 +5081,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5099,13 +5099,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5117,13 +5117,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5135,13 +5135,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5153,13 +5153,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5172,13 +5172,13 @@
       "end_date": "2016-05-20",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5190,13 +5190,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5208,13 +5208,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5226,13 +5226,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5244,13 +5244,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5262,13 +5262,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5280,13 +5280,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5298,13 +5298,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5316,13 +5316,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5334,13 +5334,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5352,13 +5352,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5370,13 +5370,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5388,13 +5388,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5406,13 +5406,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5424,13 +5424,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5442,13 +5442,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5460,13 +5460,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5478,13 +5478,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5496,13 +5496,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5514,13 +5514,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5532,13 +5532,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5550,13 +5550,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5568,13 +5568,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5586,13 +5586,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5604,13 +5604,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5622,13 +5622,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5640,13 +5640,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5658,13 +5658,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5676,13 +5676,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5694,13 +5694,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5712,13 +5712,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5730,13 +5730,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5748,13 +5748,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5766,13 +5766,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5784,13 +5784,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5802,13 +5802,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5820,13 +5820,13 @@
       "start_date": "2016-09-02",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5838,13 +5838,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5856,13 +5856,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5874,13 +5874,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5893,13 +5893,13 @@
       "end_date": "2016-10-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5911,13 +5911,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5929,13 +5929,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5947,13 +5947,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5965,13 +5965,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -5983,13 +5983,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6001,13 +6001,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6019,13 +6019,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6037,13 +6037,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6055,13 +6055,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6073,13 +6073,13 @@
       "start_date": "2016-05-26",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6091,13 +6091,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6109,13 +6109,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6127,13 +6127,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6145,13 +6145,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6163,13 +6163,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6181,13 +6181,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6199,13 +6199,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6217,13 +6217,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6235,13 +6235,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6253,13 +6253,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6271,13 +6271,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6289,13 +6289,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6308,13 +6308,13 @@
       "end_date": "2016-05-20",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6326,13 +6326,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6344,13 +6344,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6362,13 +6362,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6380,13 +6380,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6398,13 +6398,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6416,13 +6416,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6434,13 +6434,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6452,13 +6452,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     },
     {
@@ -6470,13 +6470,13 @@
       "start_date": "2016-02-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:zh_TW": "國會議員",
-        "lang:en_US": "member of parliament"
+        "lang:zh-tw": "國會議員",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q6310593",
       "role": {
-        "lang:zh_TW": "立法委員",
-        "lang:en_US": "Member of the Legislative Yuan"
+        "lang:zh-tw": "立法委員",
+        "lang:en": "Member of the Legislative Yuan"
       }
     }
   ]

--- a/legislative/Q7676191/Q49996581/popolo-m17n.json
+++ b/legislative/Q7676191/Q49996581/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "張世賢",
-        "lang:en_US": "Marco Chang"
+        "lang:zh-tw": "張世賢",
+        "lang:en": "Marco Chang"
       },
       "id": "Q11068022",
       "identifiers": [
@@ -18,7 +18,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林宜瑾"
+        "lang:zh-tw": "林宜瑾"
       },
       "id": "Q15905278",
       "identifiers": [
@@ -33,7 +33,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡旺詮"
+        "lang:zh-tw": "蔡旺詮"
       },
       "id": "Q15942320",
       "identifiers": [
@@ -48,7 +48,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳怡珍"
+        "lang:zh-tw": "陳怡珍"
       },
       "id": "Q17502266",
       "identifiers": [
@@ -63,8 +63,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭國文",
-        "lang:en_US": "Kuo Kuo-wen"
+        "lang:zh-tw": "郭國文",
+        "lang:en": "Kuo Kuo-wen"
       },
       "id": "Q22100706",
       "identifiers": [
@@ -79,7 +79,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李退之"
+        "lang:zh-tw": "李退之"
       },
       "id": "Q30943269",
       "identifiers": [
@@ -94,8 +94,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴惠員",
-        "lang:en_US": "Lia Hui-Yuan"
+        "lang:zh-tw": "賴惠員",
+        "lang:en": "Lia Hui-Yuan"
       },
       "id": "Q30946589",
       "identifiers": [
@@ -110,7 +110,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "趙昆原"
+        "lang:zh-tw": "趙昆原"
       },
       "id": "Q50081830",
       "identifiers": [
@@ -125,7 +125,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡育輝"
+        "lang:zh-tw": "蔡育輝"
       },
       "id": "Q50082016",
       "identifiers": [
@@ -140,7 +140,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "侯澄財"
+        "lang:zh-tw": "侯澄財"
       },
       "id": "Q50082089",
       "identifiers": [
@@ -155,7 +155,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝財旺"
+        "lang:zh-tw": "謝財旺"
       },
       "id": "Q50082165",
       "identifiers": [
@@ -170,7 +170,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳文賢"
+        "lang:zh-tw": "陳文賢"
       },
       "id": "Q50082227",
       "identifiers": [
@@ -185,7 +185,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭秀珠"
+        "lang:zh-tw": "郭秀珠"
       },
       "id": "Q50082298",
       "identifiers": [
@@ -200,7 +200,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳通龍"
+        "lang:zh-tw": "吳通龍"
       },
       "id": "Q50082341",
       "identifiers": [
@@ -215,7 +215,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡秋蘭"
+        "lang:zh-tw": "蔡秋蘭"
       },
       "id": "Q50082382",
       "identifiers": [
@@ -230,7 +230,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳朝來"
+        "lang:zh-tw": "陳朝來"
       },
       "id": "Q50082420",
       "identifiers": [
@@ -245,7 +245,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡蘇秋金"
+        "lang:zh-tw": "蔡蘇秋金"
       },
       "id": "Q50082450",
       "identifiers": [
@@ -260,7 +260,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "梁順發"
+        "lang:zh-tw": "梁順發"
       },
       "id": "Q50082492",
       "identifiers": [
@@ -275,7 +275,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林志展"
+        "lang:zh-tw": "林志展"
       },
       "id": "Q50082533",
       "identifiers": [
@@ -290,7 +290,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林全忠"
+        "lang:zh-tw": "林全忠"
       },
       "id": "Q50082578",
       "identifiers": [
@@ -305,7 +305,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林志聰"
+        "lang:zh-tw": "林志聰"
       },
       "id": "Q50082623",
       "identifiers": [
@@ -320,7 +320,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王峻潭"
+        "lang:zh-tw": "王峻潭"
       },
       "id": "Q50082673",
       "identifiers": [
@@ -335,7 +335,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳秋萍"
+        "lang:zh-tw": "陳秋萍"
       },
       "id": "Q50082819",
       "identifiers": [
@@ -350,7 +350,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "楊中成"
+        "lang:zh-tw": "楊中成"
       },
       "id": "Q50082866",
       "identifiers": [
@@ -365,7 +365,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林燕祝"
+        "lang:zh-tw": "林燕祝"
       },
       "id": "Q50082968",
       "identifiers": [
@@ -380,7 +380,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林阳乙"
+        "lang:zh-tw": "林阳乙"
       },
       "id": "Q50083019",
       "identifiers": [
@@ -395,7 +395,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李坤煌"
+        "lang:zh-tw": "李坤煌"
       },
       "id": "Q50083063",
       "identifiers": [
@@ -410,7 +410,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林慶鎭"
+        "lang:zh-tw": "林慶鎭"
       },
       "id": "Q50083119",
       "identifiers": [
@@ -425,7 +425,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭信良"
+        "lang:zh-tw": "郭信良"
       },
       "id": "Q50083155",
       "identifiers": [
@@ -440,7 +440,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李中岑"
+        "lang:zh-tw": "李中岑"
       },
       "id": "Q50083207",
       "identifiers": [
@@ -455,7 +455,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王錦德"
+        "lang:zh-tw": "王錦德"
       },
       "id": "Q50083246",
       "identifiers": [
@@ -470,7 +470,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林炳利"
+        "lang:zh-tw": "林炳利"
       },
       "id": "Q50083290",
       "identifiers": [
@@ -485,7 +485,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭清華"
+        "lang:zh-tw": "郭清華"
       },
       "id": "Q50083326",
       "identifiers": [
@@ -500,7 +500,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許至椿"
+        "lang:zh-tw": "許至椿"
       },
       "id": "Q50083404",
       "identifiers": [
@@ -515,7 +515,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪玉鳳"
+        "lang:zh-tw": "洪玉鳳"
       },
       "id": "Q50083553",
       "identifiers": [
@@ -530,7 +530,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "盧崑福"
+        "lang:zh-tw": "盧崑福"
       },
       "id": "Q50083601",
       "identifiers": [
@@ -545,7 +545,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾順良"
+        "lang:zh-tw": "曾順良"
       },
       "id": "Q50083726",
       "identifiers": [
@@ -560,7 +560,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳金鐘"
+        "lang:zh-tw": "陳金鐘"
       },
       "id": "Q50083790",
       "identifiers": [
@@ -575,7 +575,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾培雅"
+        "lang:zh-tw": "曾培雅"
       },
       "id": "Q50083822",
       "identifiers": [
@@ -590,7 +590,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陸美祈"
+        "lang:zh-tw": "陸美祈"
       },
       "id": "Q50083865",
       "identifiers": [
@@ -605,7 +605,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "呂維胤"
+        "lang:zh-tw": "呂維胤"
       },
       "id": "Q50083907",
       "identifiers": [
@@ -620,7 +620,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡淑惠"
+        "lang:zh-tw": "蔡淑惠"
       },
       "id": "Q50083941",
       "identifiers": [
@@ -635,7 +635,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林美燕"
+        "lang:zh-tw": "林美燕"
       },
       "id": "Q50083985",
       "identifiers": [
@@ -650,7 +650,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "莊玉珠"
+        "lang:zh-tw": "莊玉珠"
       },
       "id": "Q50084024",
       "identifiers": [
@@ -665,7 +665,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳特清"
+        "lang:zh-tw": "陳特清"
       },
       "id": "Q50084053",
       "identifiers": [
@@ -680,7 +680,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "杜素吟"
+        "lang:zh-tw": "杜素吟"
       },
       "id": "Q50084088",
       "identifiers": [
@@ -695,7 +695,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張伯祿"
+        "lang:zh-tw": "張伯祿"
       },
       "id": "Q50084124",
       "identifiers": [
@@ -710,7 +710,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "曾王雅雲"
+        "lang:zh-tw": "曾王雅雲"
       },
       "id": "Q50084166",
       "identifiers": [
@@ -725,7 +725,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉正昌"
+        "lang:zh-tw": "劉正昌"
       },
       "id": "Q50084207",
       "identifiers": [
@@ -740,7 +740,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "蔡玉枝"
+        "lang:zh-tw": "蔡玉枝"
       },
       "id": "Q50084240",
       "identifiers": [
@@ -755,7 +755,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "谷暮‧哈就"
+        "lang:zh-tw": "谷暮‧哈就"
       },
       "id": "Q50084280",
       "identifiers": [
@@ -770,8 +770,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "唐碧娥",
-        "lang:en_US": "Tang Bi-a"
+        "lang:zh-tw": "唐碧娥",
+        "lang:en": "Tang Bi-a"
       },
       "id": "Q7682659",
       "identifiers": [
@@ -786,7 +786,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李全教"
+        "lang:zh-tw": "李全教"
       },
       "id": "Q8274968",
       "identifiers": [
@@ -801,8 +801,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝龍介",
-        "lang:en_US": "Chiā Liông-kài"
+        "lang:zh-tw": "謝龍介",
+        "lang:en": "Chiā Liông-kài"
       },
       "id": "Q8277906",
       "identifiers": [
@@ -817,7 +817,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "邱莉莉"
+        "lang:zh-tw": "邱莉莉"
       },
       "id": "Q8347743",
       "identifiers": [
@@ -832,7 +832,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "賴美惠"
+        "lang:zh-tw": "賴美惠"
       },
       "id": "Q8350016",
       "identifiers": [
@@ -847,8 +847,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李文正",
-        "lang:en_US": "Mochtar Riady"
+        "lang:zh-tw": "李文正",
+        "lang:en": "Mochtar Riady"
       },
       "id": "Q8995080",
       "identifiers": [
@@ -863,7 +863,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王家貞"
+        "lang:zh-tw": "王家貞"
       },
       "id": "Q9314157",
       "identifiers": [
@@ -880,8 +880,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "臺南市議會",
-        "lang:en_US": "Tainan City Council"
+        "lang:zh-tw": "臺南市議會",
+        "lang:en": "Tainan City Council"
       },
       "id": "Q7676191",
       "classification": "branch",
@@ -898,8 +898,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -912,8 +912,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "台灣團結聯盟",
-        "lang:en_US": "Taiwan Solidarity Union"
+        "lang:zh-tw": "台灣團結聯盟",
+        "lang:en": "Taiwan Solidarity Union"
       },
       "id": "Q706834",
       "classification": "party",
@@ -926,8 +926,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -956,8 +956,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Tainan City",
@@ -981,8 +981,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第01選區"
@@ -1005,8 +1005,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第02選區"
@@ -1029,8 +1029,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第03選區"
@@ -1053,8 +1053,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第04選區"
@@ -1077,8 +1077,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第05選區"
@@ -1101,8 +1101,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第06選區"
@@ -1125,8 +1125,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第07選區"
@@ -1149,8 +1149,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第08選區"
@@ -1173,8 +1173,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第09選區"
@@ -1197,8 +1197,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第10選區"
@@ -1221,8 +1221,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第11選區"
@@ -1245,8 +1245,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第12選區"
@@ -1269,8 +1269,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第13選區"
@@ -1293,8 +1293,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第14選區"
@@ -1317,8 +1317,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第15選區"
@@ -1341,8 +1341,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第16選區"
@@ -1365,8 +1365,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第17選區"
@@ -1389,8 +1389,8 @@
         "Q49256480"
       ],
       "type": {
-        "lang:zh_TW": "臺南市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Tainan"
+        "lang:zh-tw": "臺南市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
         "lang:zh_TW": "臺南市第18選區"
@@ -1413,8 +1413,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -1433,12 +1433,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1450,12 +1450,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1467,12 +1467,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1484,12 +1484,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1502,12 +1502,12 @@
       "end_date": "2016-05-19",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1519,12 +1519,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1536,12 +1536,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1552,12 +1552,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1569,12 +1569,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1586,12 +1586,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1602,12 +1602,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1619,12 +1619,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1635,12 +1635,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1652,12 +1652,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1668,12 +1668,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1684,12 +1684,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1701,12 +1701,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1717,12 +1717,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1734,12 +1734,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1751,12 +1751,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1768,12 +1768,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1785,12 +1785,12 @@
       "start_date": "2016-08-30",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1802,12 +1802,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1819,12 +1819,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1836,12 +1836,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1852,12 +1852,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1869,12 +1869,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1885,12 +1885,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1902,12 +1902,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1919,12 +1919,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1936,12 +1936,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1952,12 +1952,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1969,12 +1969,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -1986,12 +1986,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2003,12 +2003,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2020,12 +2020,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2036,12 +2036,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2053,12 +2053,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2070,12 +2070,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2087,12 +2087,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2104,12 +2104,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2121,12 +2121,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2138,12 +2138,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2154,12 +2154,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2171,12 +2171,12 @@
       "end_date": "2017-01-29",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2187,12 +2187,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2204,12 +2204,12 @@
       "end_date": "2015-12-19",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2220,12 +2220,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2237,12 +2237,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2254,12 +2254,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2270,12 +2270,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2287,12 +2287,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2305,12 +2305,12 @@
       "end_date": "2016-08-30",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2322,12 +2322,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2339,12 +2339,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2356,12 +2356,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2373,12 +2373,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     },
     {
@@ -2390,12 +2390,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256480",
       "role": {
-        "lang:zh_TW": "臺南市議員"
+        "lang:zh-tw": "臺南市議員"
       }
     }
   ]

--- a/legislative/Q7676278/Q49996573/popolo-m17n.json
+++ b/legislative/Q7676278/Q49996573/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:zh_TW": "黃向羣"
+        "lang:zh-tw": "黃向羣"
       },
       "id": "Q11176040",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "鍾小平"
+        "lang:zh-tw": "鍾小平"
       },
       "id": "Q15897619",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王閔生"
+        "lang:zh-tw": "王閔生"
       },
       "id": "Q15926220",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "葉林傳"
+        "lang:zh-tw": "葉林傳"
       },
       "id": "Q16904293",
       "identifiers": [
@@ -62,8 +62,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "何志偉",
-        "lang:en_US": "Mark, Ho"
+        "lang:zh-tw": "何志偉",
+        "lang:en": "Mark, Ho"
       },
       "id": "Q16926490",
       "identifiers": [
@@ -78,7 +78,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "厲耿桂芳"
+        "lang:zh-tw": "厲耿桂芳"
       },
       "id": "Q17370642",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林世宗"
+        "lang:zh-tw": "林世宗"
       },
       "id": "Q17499378",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "童仲彥"
+        "lang:zh-tw": "童仲彥"
       },
       "id": "Q17499593",
       "identifiers": [
@@ -123,7 +123,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "黃珊珊"
+        "lang:zh-tw": "黃珊珊"
       },
       "id": "Q18226621",
       "identifiers": [
@@ -138,7 +138,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李慶鋒"
+        "lang:zh-tw": "李慶鋒"
       },
       "id": "Q18653805",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "謝維洲"
+        "lang:zh-tw": "謝維洲"
       },
       "id": "Q18659294",
       "identifiers": [
@@ -168,7 +168,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李彥秀"
+        "lang:zh-tw": "李彥秀"
       },
       "id": "Q20063502",
       "identifiers": [
@@ -183,7 +183,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "闕枚莎"
+        "lang:zh-tw": "闕枚莎"
       },
       "id": "Q20689197",
       "identifiers": [
@@ -198,7 +198,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳彥伯"
+        "lang:zh-tw": "陳彥伯"
       },
       "id": "Q20689220",
       "identifiers": [
@@ -213,7 +213,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳義洲"
+        "lang:zh-tw": "陳義洲"
       },
       "id": "Q20689237",
       "identifiers": [
@@ -228,7 +228,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李芳儒"
+        "lang:zh-tw": "李芳儒"
       },
       "id": "Q21016981",
       "identifiers": [
@@ -243,7 +243,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐世勲"
+        "lang:zh-tw": "徐世勲"
       },
       "id": "Q22099965",
       "identifiers": [
@@ -258,7 +258,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "簡舒培"
+        "lang:zh-tw": "簡舒培"
       },
       "id": "Q30942877",
       "identifiers": [
@@ -273,7 +273,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王威中"
+        "lang:zh-tw": "王威中"
       },
       "id": "Q30942878",
       "identifiers": [
@@ -288,7 +288,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周威佑"
+        "lang:zh-tw": "周威佑"
       },
       "id": "Q30942892",
       "identifiers": [
@@ -303,7 +303,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顏若芳"
+        "lang:zh-tw": "顏若芳"
       },
       "id": "Q30942894",
       "identifiers": [
@@ -318,7 +318,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許家蓓"
+        "lang:zh-tw": "許家蓓"
       },
       "id": "Q38958796",
       "identifiers": [
@@ -333,8 +333,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李新",
-        "lang:en_US": "Li Xincong"
+        "lang:zh-tw": "李新",
+        "lang:en": "Li Xincong"
       },
       "id": "Q45434907",
       "identifiers": [
@@ -349,7 +349,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳政忠"
+        "lang:zh-tw": "陳政忠"
       },
       "id": "Q47668356",
       "identifiers": [
@@ -364,7 +364,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李傅中武"
+        "lang:zh-tw": "李傅中武"
       },
       "id": "Q49806361",
       "identifiers": [
@@ -379,7 +379,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳慈慧"
+        "lang:zh-tw": "陳慈慧"
       },
       "id": "Q50005539",
       "identifiers": [
@@ -394,7 +394,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "汪志冰"
+        "lang:zh-tw": "汪志冰"
       },
       "id": "Q50005922",
       "identifiers": [
@@ -409,7 +409,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳重文"
+        "lang:zh-tw": "陳重文"
       },
       "id": "Q50007141",
       "identifiers": [
@@ -424,7 +424,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王孝維"
+        "lang:zh-tw": "王孝維"
       },
       "id": "Q50011563",
       "identifiers": [
@@ -439,7 +439,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "江志銘"
+        "lang:zh-tw": "江志銘"
       },
       "id": "Q50012140",
       "identifiers": [
@@ -454,7 +454,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳永德"
+        "lang:zh-tw": "陳永德"
       },
       "id": "Q50013837",
       "identifiers": [
@@ -469,7 +469,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "張茂楠"
+        "lang:zh-tw": "張茂楠"
       },
       "id": "Q50014211",
       "identifiers": [
@@ -484,7 +484,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "戴錫欽"
+        "lang:zh-tw": "戴錫欽"
       },
       "id": "Q50014251",
       "identifiers": [
@@ -499,7 +499,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳孋輝"
+        "lang:zh-tw": "陳孋輝"
       },
       "id": "Q50014287",
       "identifiers": [
@@ -514,7 +514,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林亭君"
+        "lang:zh-tw": "林亭君"
       },
       "id": "Q50014443",
       "identifiers": [
@@ -529,7 +529,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳炳甫"
+        "lang:zh-tw": "陳炳甫"
       },
       "id": "Q50014512",
       "identifiers": [
@@ -544,7 +544,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "郭昭巖"
+        "lang:zh-tw": "郭昭巖"
       },
       "id": "Q50015312",
       "identifiers": [
@@ -559,7 +559,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "劉耀仁"
+        "lang:zh-tw": "劉耀仁"
       },
       "id": "Q50015420",
       "identifiers": [
@@ -574,7 +574,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王欣儀"
+        "lang:zh-tw": "王欣儀"
       },
       "id": "Q50015767",
       "identifiers": [
@@ -589,7 +589,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳錦祥"
+        "lang:zh-tw": "陳錦祥"
       },
       "id": "Q50016023",
       "identifiers": [
@@ -604,7 +604,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "周柏雅"
+        "lang:zh-tw": "周柏雅"
       },
       "id": "Q7250870",
       "identifiers": [
@@ -619,7 +619,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "陳建銘"
+        "lang:zh-tw": "陳建銘"
       },
       "id": "Q8272145",
       "identifiers": [
@@ -634,8 +634,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李慶元",
-        "lang:en_US": "Li Chinyuan"
+        "lang:zh-tw": "李慶元",
+        "lang:en": "Li Chinyuan"
       },
       "id": "Q8274364",
       "identifiers": [
@@ -650,8 +650,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "歐陽龍",
-        "lang:en_US": "Long Ou-yang"
+        "lang:zh-tw": "歐陽龍",
+        "lang:en": "Long Ou-yang"
       },
       "id": "Q8275686",
       "identifiers": [
@@ -666,7 +666,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "秦慧珠"
+        "lang:zh-tw": "秦慧珠"
       },
       "id": "Q8275964",
       "identifiers": [
@@ -681,7 +681,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳志剛"
+        "lang:zh-tw": "吳志剛"
       },
       "id": "Q8277252",
       "identifiers": [
@@ -696,7 +696,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳碧珠"
+        "lang:zh-tw": "吳碧珠"
       },
       "id": "Q8277283",
       "identifiers": [
@@ -711,7 +711,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "徐弘庭"
+        "lang:zh-tw": "徐弘庭"
       },
       "id": "Q8279467",
       "identifiers": [
@@ -726,7 +726,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "應曉薇"
+        "lang:zh-tw": "應曉薇"
       },
       "id": "Q8279470",
       "identifiers": [
@@ -741,7 +741,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "高嘉瑜"
+        "lang:zh-tw": "高嘉瑜"
       },
       "id": "Q8348414",
       "identifiers": [
@@ -756,7 +756,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "許淑華"
+        "lang:zh-tw": "許淑華"
       },
       "id": "Q8349100",
       "identifiers": [
@@ -771,7 +771,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "李建昌"
+        "lang:zh-tw": "李建昌"
       },
       "id": "Q8349706",
       "identifiers": [
@@ -786,7 +786,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "梁文傑"
+        "lang:zh-tw": "梁文傑"
       },
       "id": "Q8349924",
       "identifiers": [
@@ -801,7 +801,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王世堅"
+        "lang:zh-tw": "王世堅"
       },
       "id": "Q8350423",
       "identifiers": [
@@ -816,8 +816,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳思瑤",
-        "lang:en_US": "Rosalia Wu"
+        "lang:zh-tw": "吳思瑤",
+        "lang:en": "Rosalia Wu"
       },
       "id": "Q8350455",
       "identifiers": [
@@ -832,7 +832,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "洪健益"
+        "lang:zh-tw": "洪健益"
       },
       "id": "Q8351000",
       "identifiers": [
@@ -847,7 +847,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "顏聖冠"
+        "lang:zh-tw": "顏聖冠"
       },
       "id": "Q8351182",
       "identifiers": [
@@ -862,7 +862,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林瑞圖"
+        "lang:zh-tw": "林瑞圖"
       },
       "id": "Q8351582",
       "identifiers": [
@@ -877,8 +877,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "阮昭雄",
-        "lang:en_US": "Ruan Jhao-syong"
+        "lang:zh-tw": "阮昭雄",
+        "lang:en": "Ruan Jhao-syong"
       },
       "id": "Q8351790",
       "identifiers": [
@@ -893,7 +893,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "林國成"
+        "lang:zh-tw": "林國成"
       },
       "id": "Q8982750",
       "identifiers": [
@@ -908,7 +908,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "潘懷宗"
+        "lang:zh-tw": "潘懷宗"
       },
       "id": "Q9025162",
       "identifiers": [
@@ -923,7 +923,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "王鴻薇"
+        "lang:zh-tw": "王鴻薇"
       },
       "id": "Q9067119",
       "identifiers": [
@@ -938,7 +938,7 @@
     },
     {
       "name": {
-        "lang:zh_TW": "吳世正"
+        "lang:zh-tw": "吳世正"
       },
       "id": "Q9118836",
       "identifiers": [
@@ -955,8 +955,8 @@
   "organizations": [
     {
       "name": {
-        "lang:zh_TW": "臺北市議會",
-        "lang:en_US": "Taipei City Council"
+        "lang:zh-tw": "臺北市議會",
+        "lang:en": "Taipei City Council"
       },
       "id": "Q7676278",
       "classification": "branch",
@@ -973,8 +973,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "親民黨",
-        "lang:en_US": "People First Party"
+        "lang:zh-tw": "親民黨",
+        "lang:en": "People First Party"
       },
       "id": "Q1442482",
       "classification": "party",
@@ -987,8 +987,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民國黨",
-        "lang:en_US": "Minkuotang"
+        "lang:zh-tw": "民國黨",
+        "lang:en": "Minkuotang"
       },
       "id": "Q19684454",
       "classification": "party",
@@ -1001,8 +1001,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "新黨",
-        "lang:en_US": "New Party"
+        "lang:zh-tw": "新黨",
+        "lang:en": "New Party"
       },
       "id": "Q2284361",
       "classification": "party",
@@ -1015,8 +1015,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "中國國民黨",
-        "lang:en_US": "Kuomintang"
+        "lang:zh-tw": "中國國民黨",
+        "lang:en": "Kuomintang"
       },
       "id": "Q31113",
       "classification": "party",
@@ -1029,8 +1029,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "台灣團結聯盟",
-        "lang:en_US": "Taiwan Solidarity Union"
+        "lang:zh-tw": "台灣團結聯盟",
+        "lang:en": "Taiwan Solidarity Union"
       },
       "id": "Q706834",
       "classification": "party",
@@ -1043,8 +1043,8 @@
     },
     {
       "name": {
-        "lang:zh_TW": "民主進步黨",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:zh-tw": "民主進步黨",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q903822",
       "classification": "party",
@@ -1073,8 +1073,8 @@
         "Q30185"
       ],
       "type": {
-        "lang:zh_TW": "直轄市",
-        "lang:en_US": "special municipality"
+        "lang:zh-tw": "直轄市",
+        "lang:en": "special municipality"
       },
       "name": {
         "lang:en_US": "Taipei City",
@@ -1098,8 +1098,8 @@
         "Q49256298"
       ],
       "type": {
-        "lang:zh_TW": "臺北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taipei"
+        "lang:zh-tw": "臺北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
         "lang:zh_TW": "臺北市第01選區"
@@ -1122,8 +1122,8 @@
         "Q49256298"
       ],
       "type": {
-        "lang:zh_TW": "臺北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taipei"
+        "lang:zh-tw": "臺北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
         "lang:zh_TW": "臺北市第02選區"
@@ -1146,8 +1146,8 @@
         "Q49256298"
       ],
       "type": {
-        "lang:zh_TW": "臺北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taipei"
+        "lang:zh-tw": "臺北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
         "lang:zh_TW": "臺北市第03選區"
@@ -1170,8 +1170,8 @@
         "Q49256298"
       ],
       "type": {
-        "lang:zh_TW": "臺北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taipei"
+        "lang:zh-tw": "臺北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
         "lang:zh_TW": "臺北市第04選區"
@@ -1194,8 +1194,8 @@
         "Q49256298"
       ],
       "type": {
-        "lang:zh_TW": "臺北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taipei"
+        "lang:zh-tw": "臺北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
         "lang:zh_TW": "臺北市第05選區"
@@ -1218,8 +1218,8 @@
         "Q49256298"
       ],
       "type": {
-        "lang:zh_TW": "臺北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taipei"
+        "lang:zh-tw": "臺北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
         "lang:zh_TW": "臺北市第06選區"
@@ -1242,8 +1242,8 @@
         "Q49256298"
       ],
       "type": {
-        "lang:zh_TW": "臺北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taipei"
+        "lang:zh-tw": "臺北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
         "lang:zh_TW": "臺北市第07選區"
@@ -1266,8 +1266,8 @@
         "Q49256298"
       ],
       "type": {
-        "lang:zh_TW": "臺北市議員選區",
-        "lang:en_US": "Constituency of Regional Councilors of Taipei"
+        "lang:zh-tw": "臺北市議員選區",
+        "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
         "lang:zh_TW": "臺北市第08選區"
@@ -1290,8 +1290,8 @@
         "Q702650"
       ],
       "type": {
-        "lang:zh_TW": "國家",
-        "lang:en_US": "country"
+        "lang:zh-tw": "國家",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Taiwan",
@@ -1310,12 +1310,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1327,12 +1327,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1344,12 +1344,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1361,12 +1361,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1378,12 +1378,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1395,12 +1395,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1412,12 +1412,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1428,12 +1428,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1445,12 +1445,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1462,12 +1462,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1479,12 +1479,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1497,12 +1497,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1514,12 +1514,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1531,12 +1531,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1548,12 +1548,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1565,12 +1565,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1582,12 +1582,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1599,12 +1599,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1616,12 +1616,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1633,12 +1633,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1650,12 +1650,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1667,12 +1667,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1685,12 +1685,12 @@
       "end_date": "2017-09-28",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1701,12 +1701,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1718,12 +1718,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1735,12 +1735,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1752,12 +1752,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1769,12 +1769,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1786,12 +1786,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1803,12 +1803,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1820,12 +1820,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1837,12 +1837,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1854,12 +1854,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1871,12 +1871,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1888,12 +1888,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1905,12 +1905,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1922,12 +1922,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1939,12 +1939,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1956,12 +1956,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1973,12 +1973,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -1990,12 +1990,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2007,12 +2007,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2023,12 +2023,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2040,12 +2040,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2057,12 +2057,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2074,12 +2074,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2091,12 +2091,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2108,12 +2108,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2125,12 +2125,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2142,12 +2142,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2159,12 +2159,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2176,12 +2176,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2193,12 +2193,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2210,12 +2210,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2228,12 +2228,12 @@
       "end_date": "2016-01-31",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2245,12 +2245,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2262,12 +2262,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2278,12 +2278,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2295,12 +2295,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2312,12 +2312,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2329,12 +2329,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2346,12 +2346,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     },
     {
@@ -2363,12 +2363,12 @@
       "start_date": "2014-12-25",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:zh_TW": "地方議會議員",
-        "lang:en_US": "councillor"
+        "lang:zh-tw": "地方議會議員",
+        "lang:en": "councillor"
       },
       "role_code": "Q49256298",
       "role": {
-        "lang:zh_TW": "臺北市議員"
+        "lang:zh-tw": "臺北市議員"
       }
     }
   ]


### PR DESCRIPTION
This moves this proto-commons- repo to use Wikidata language codes in the generated files, instead of Facebook locale codes, after the change introduced by be979f9 of commons-builder (later fixed in 0e34a06).