### PR TITLE
Fix boundary lang columns

### DIFF
--- a/boundaries/index.json
+++ b/boundaries/index.json
@@ -9,8 +9,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "name_en",
-      "lang:zh_TW": "name"
+      "lang:en": "name_en",
+      "lang:zh-tw": "name"
     }
   },
   {
@@ -23,8 +23,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "name_en",
-      "lang:zh_TW": "name"
+      "lang:en": "name_en",
+      "lang:zh-tw": "name"
     }
   },
   {
@@ -37,8 +37,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "name_en",
-      "lang:zh_TW": "name"
+      "lang:en": "name_en",
+      "lang:zh-tw": "name"
     }
   },
   {
@@ -51,8 +51,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "name_en",
-      "lang:zh_TW": "name"
+      "lang:en": "name_en",
+      "lang:zh-tw": "name"
     }
   },
   {
@@ -69,8 +69,8 @@
       "match": "country:tw/special-municipality"
     },
     "name_columns": {
-      "lang:en_US": "COUNTYENG",
-      "lang:zh_TW": "COUNTYNAME"
+      "lang:en": "COUNTYENG",
+      "lang:zh-tw": "COUNTYNAME"
     }
   },
   {
@@ -87,8 +87,8 @@
       "match": "country:tw/city"
     },
     "name_columns": {
-      "lang:en_US": "COUNTYENG",
-      "lang:zh_TW": "COUNTYNAME"
+      "lang:en": "COUNTYENG",
+      "lang:zh-tw": "COUNTYNAME"
     }
   },
   {
@@ -105,8 +105,8 @@
       "match": "country:tw/county"
     },
     "name_columns": {
-      "lang:en_US": "COUNTYENG",
-      "lang:zh_TW": "COUNTYNAME"
+      "lang:en": "COUNTYENG",
+      "lang:zh-tw": "COUNTYNAME"
     }
   },
   {
@@ -119,7 +119,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name_zh"
+      "lang:zh-tw": "name_zh"
     }
   },
   {
@@ -132,7 +132,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:nan",
@@ -149,7 +149,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/city:cyi",
@@ -166,7 +166,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:cyq",
@@ -183,7 +183,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/city:kee",
@@ -200,7 +200,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:ila",
@@ -217,7 +217,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:pif",
@@ -234,7 +234,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:cha",
@@ -251,7 +251,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/special-municipality:nwt",
@@ -268,7 +268,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/city:hsz",
@@ -285,7 +285,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:hsq",
@@ -302,7 +302,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/special-municipality:tao",
@@ -319,7 +319,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:pen",
@@ -336,7 +336,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/special-municipality:txg",
@@ -353,7 +353,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/special-municipality:tpe",
@@ -370,7 +370,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/special-municipality:tnn",
@@ -387,7 +387,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:ttt",
@@ -404,7 +404,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:hua",
@@ -421,7 +421,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:mia",
@@ -438,7 +438,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:lie",
@@ -455,7 +455,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:kin",
@@ -472,7 +472,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/county:yun",
@@ -489,7 +489,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "CONSTIT_ID"
+      "lang:zh-tw": "CONSTIT_ID"
     },
     "filter": {
       "match": "country:tw/special-municipality:khh",
@@ -506,7 +506,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:nan",
@@ -523,7 +523,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/city:cyi",
@@ -540,7 +540,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:cyq",
@@ -557,7 +557,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/city:kee",
@@ -574,7 +574,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:ila",
@@ -591,7 +591,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:pif",
@@ -608,7 +608,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:cha",
@@ -625,7 +625,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/special-municipality:nwt",
@@ -642,7 +642,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/city:hsz",
@@ -659,7 +659,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:hsq",
@@ -676,7 +676,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/special-municipality:tao",
@@ -693,7 +693,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:pen",
@@ -710,7 +710,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/special-municipality:txg",
@@ -727,7 +727,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/special-municipality:tpe",
@@ -744,7 +744,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/special-municipality:tnn",
@@ -761,7 +761,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:ttt",
@@ -778,7 +778,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:hua",
@@ -795,7 +795,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:mia",
@@ -812,7 +812,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:lie",
@@ -829,7 +829,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:kin",
@@ -846,7 +846,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/county:yun",
@@ -863,7 +863,7 @@
       }
     ],
     "name_columns": {
-      "lang:zh_TW": "name-zh"
+      "lang:zh-tw": "name-zh"
     },
     "filter": {
       "match": "country:tw/special-municipality:khh",

--- a/executive/Q10924139/current/popolo-m17n.json
+++ b/executive/Q10924139/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -94,8 +94,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -119,8 +119,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -144,8 +144,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -169,8 +169,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -194,8 +194,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -219,8 +219,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -244,8 +244,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -269,8 +269,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -294,8 +294,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -319,8 +319,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -344,8 +344,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -369,8 +369,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -394,8 +394,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -419,8 +419,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -444,8 +444,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -469,8 +469,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -494,8 +494,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -519,8 +519,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -544,8 +544,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -569,8 +569,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -594,8 +594,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -619,8 +619,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q10930430/current/popolo-m17n.json
+++ b/executive/Q10930430/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -94,8 +94,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -119,8 +119,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -144,8 +144,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -169,8 +169,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -194,8 +194,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -219,8 +219,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -244,8 +244,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -269,8 +269,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -294,8 +294,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -319,8 +319,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -344,8 +344,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -369,8 +369,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -394,8 +394,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -419,8 +419,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -444,8 +444,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -469,8 +469,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -494,8 +494,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -519,8 +519,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -544,8 +544,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -569,8 +569,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -594,8 +594,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -619,8 +619,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q10949116/current/popolo-m17n.json
+++ b/executive/Q10949116/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -94,8 +94,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -119,8 +119,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -144,8 +144,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -169,8 +169,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -194,8 +194,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -219,8 +219,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -244,8 +244,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -269,8 +269,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -294,8 +294,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -319,8 +319,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -344,8 +344,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -369,8 +369,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -394,8 +394,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -419,8 +419,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -444,8 +444,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -469,8 +469,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -494,8 +494,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -519,8 +519,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -544,8 +544,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -569,8 +569,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -594,8 +594,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -619,8 +619,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q11042707/current/popolo-m17n.json
+++ b/executive/Q11042707/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -51,8 +51,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -76,8 +76,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -101,8 +101,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -126,8 +126,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -151,8 +151,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -176,8 +176,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -201,8 +201,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -226,8 +226,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -251,8 +251,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -276,8 +276,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -301,8 +301,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -326,8 +326,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -351,8 +351,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -376,8 +376,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -401,8 +401,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -426,8 +426,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -451,8 +451,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -476,8 +476,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -501,8 +501,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -526,8 +526,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -551,8 +551,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -576,8 +576,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q11070045/current/popolo-m17n.json
+++ b/executive/Q11070045/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -51,8 +51,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -76,8 +76,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -101,8 +101,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -126,8 +126,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -151,8 +151,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -176,8 +176,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -201,8 +201,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -226,8 +226,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -251,8 +251,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -276,8 +276,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -301,8 +301,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -326,8 +326,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -351,8 +351,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -376,8 +376,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -401,8 +401,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -426,8 +426,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -451,8 +451,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -476,8 +476,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -501,8 +501,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -526,8 +526,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -551,8 +551,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -576,8 +576,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q11081380/current/popolo-m17n.json
+++ b/executive/Q11081380/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -94,8 +94,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -119,8 +119,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -144,8 +144,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -169,8 +169,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -194,8 +194,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -219,8 +219,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -244,8 +244,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -269,8 +269,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -294,8 +294,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -319,8 +319,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -344,8 +344,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -369,8 +369,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -394,8 +394,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -419,8 +419,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -444,8 +444,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -469,8 +469,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -494,8 +494,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -519,8 +519,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -544,8 +544,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -569,8 +569,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -594,8 +594,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -619,8 +619,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q11083998/current/popolo-m17n.json
+++ b/executive/Q11083998/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -94,8 +94,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -119,8 +119,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -144,8 +144,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -169,8 +169,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -194,8 +194,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -219,8 +219,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -244,8 +244,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -269,8 +269,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -294,8 +294,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -319,8 +319,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -344,8 +344,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -369,8 +369,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -394,8 +394,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -419,8 +419,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -444,8 +444,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -469,8 +469,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -494,8 +494,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -519,8 +519,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -544,8 +544,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -569,8 +569,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -594,8 +594,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -619,8 +619,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q11084050/current/popolo-m17n.json
+++ b/executive/Q11084050/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -94,8 +94,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -119,8 +119,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -144,8 +144,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -169,8 +169,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -194,8 +194,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -219,8 +219,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -244,8 +244,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -269,8 +269,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -294,8 +294,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -319,8 +319,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -344,8 +344,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -369,8 +369,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -394,8 +394,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -419,8 +419,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -444,8 +444,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -469,8 +469,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -494,8 +494,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -519,8 +519,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -544,8 +544,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -569,8 +569,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -594,8 +594,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -619,8 +619,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q15897754/current/popolo-m17n.json
+++ b/executive/Q15897754/current/popolo-m17n.json
@@ -84,8 +84,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -109,8 +109,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -134,8 +134,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -159,8 +159,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -184,8 +184,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -209,8 +209,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -234,8 +234,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -259,8 +259,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -284,8 +284,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -309,8 +309,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -334,8 +334,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -359,8 +359,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -384,8 +384,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -409,8 +409,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -434,8 +434,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -459,8 +459,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -484,8 +484,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -509,8 +509,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -534,8 +534,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -559,8 +559,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -584,8 +584,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -609,8 +609,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -634,8 +634,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q15898718/current/popolo-m17n.json
+++ b/executive/Q15898718/current/popolo-m17n.json
@@ -68,8 +68,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -93,8 +93,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -118,8 +118,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -143,8 +143,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -168,8 +168,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -193,8 +193,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -218,8 +218,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -243,8 +243,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -268,8 +268,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -293,8 +293,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -318,8 +318,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -343,8 +343,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -368,8 +368,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -393,8 +393,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -418,8 +418,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -443,8 +443,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -468,8 +468,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -493,8 +493,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -518,8 +518,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -543,8 +543,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -568,8 +568,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -593,8 +593,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -618,8 +618,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q15904117/current/popolo-m17n.json
+++ b/executive/Q15904117/current/popolo-m17n.json
@@ -55,8 +55,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -80,8 +80,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -105,8 +105,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -130,8 +130,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -155,8 +155,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -180,8 +180,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -205,8 +205,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -230,8 +230,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -255,8 +255,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -280,8 +280,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -305,8 +305,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -330,8 +330,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -355,8 +355,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -380,8 +380,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -405,8 +405,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -430,8 +430,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -455,8 +455,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -480,8 +480,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -505,8 +505,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -530,8 +530,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -555,8 +555,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -580,8 +580,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -605,8 +605,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q15909106/current/popolo-m17n.json
+++ b/executive/Q15909106/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -94,8 +94,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -119,8 +119,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -144,8 +144,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -169,8 +169,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -194,8 +194,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -219,8 +219,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -244,8 +244,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -269,8 +269,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -294,8 +294,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -319,8 +319,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -344,8 +344,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -369,8 +369,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -394,8 +394,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -419,8 +419,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -444,8 +444,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -469,8 +469,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -494,8 +494,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -519,8 +519,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -544,8 +544,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -569,8 +569,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -594,8 +594,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -619,8 +619,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q15909984/current/popolo-m17n.json
+++ b/executive/Q15909984/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -51,8 +51,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -76,8 +76,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -101,8 +101,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -126,8 +126,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -151,8 +151,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -176,8 +176,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -201,8 +201,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -226,8 +226,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -251,8 +251,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -276,8 +276,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -301,8 +301,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -326,8 +326,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -351,8 +351,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -376,8 +376,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -401,8 +401,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -426,8 +426,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -451,8 +451,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -476,8 +476,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -501,8 +501,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -526,8 +526,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -551,8 +551,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -576,8 +576,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q16976490/current/popolo-m17n.json
+++ b/executive/Q16976490/current/popolo-m17n.json
@@ -55,8 +55,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -80,8 +80,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -105,8 +105,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -130,8 +130,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -155,8 +155,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -180,8 +180,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -205,8 +205,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -230,8 +230,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -255,8 +255,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -280,8 +280,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -305,8 +305,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -330,8 +330,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -355,8 +355,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -380,8 +380,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -405,8 +405,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -430,8 +430,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -455,8 +455,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -480,8 +480,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -505,8 +505,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -530,8 +530,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -555,8 +555,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -580,8 +580,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -605,8 +605,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q17011999/current/popolo-m17n.json
+++ b/executive/Q17011999/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -51,8 +51,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -76,8 +76,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -101,8 +101,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -126,8 +126,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -151,8 +151,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -176,8 +176,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -201,8 +201,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -226,8 +226,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -251,8 +251,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -276,8 +276,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -301,8 +301,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -326,8 +326,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -351,8 +351,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -376,8 +376,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -401,8 +401,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -426,8 +426,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -451,8 +451,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -476,8 +476,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -501,8 +501,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -526,8 +526,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -551,8 +551,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -576,8 +576,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q17500943/current/popolo-m17n.json
+++ b/executive/Q17500943/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -94,8 +94,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -119,8 +119,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -144,8 +144,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -169,8 +169,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -194,8 +194,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -219,8 +219,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -244,8 +244,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -269,8 +269,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -294,8 +294,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -319,8 +319,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -344,8 +344,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -369,8 +369,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -394,8 +394,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -419,8 +419,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -444,8 +444,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -469,8 +469,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -494,8 +494,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -519,8 +519,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -544,8 +544,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -569,8 +569,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -594,8 +594,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -619,8 +619,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q18658204/current/popolo-m17n.json
+++ b/executive/Q18658204/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -94,8 +94,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -119,8 +119,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -144,8 +144,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -169,8 +169,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -194,8 +194,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -219,8 +219,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -244,8 +244,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -269,8 +269,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -294,8 +294,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -319,8 +319,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -344,8 +344,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -369,8 +369,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -394,8 +394,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -419,8 +419,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -444,8 +444,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -469,8 +469,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -494,8 +494,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -519,8 +519,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -544,8 +544,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -569,8 +569,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -594,8 +594,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -619,8 +619,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q18658266/current/popolo-m17n.json
+++ b/executive/Q18658266/current/popolo-m17n.json
@@ -55,8 +55,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -80,8 +80,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -105,8 +105,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -130,8 +130,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -155,8 +155,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -180,8 +180,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -205,8 +205,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -230,8 +230,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -255,8 +255,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -280,8 +280,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -305,8 +305,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -330,8 +330,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -355,8 +355,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -380,8 +380,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -405,8 +405,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -430,8 +430,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -455,8 +455,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -480,8 +480,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -505,8 +505,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -530,8 +530,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -555,8 +555,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -580,8 +580,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -605,8 +605,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q50306736/current/popolo-m17n.json
+++ b/executive/Q50306736/current/popolo-m17n.json
@@ -72,8 +72,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -97,8 +97,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -122,8 +122,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -147,8 +147,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -172,8 +172,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -197,8 +197,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -222,8 +222,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -247,8 +247,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -272,8 +272,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -297,8 +297,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -322,8 +322,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -347,8 +347,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -372,8 +372,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -397,8 +397,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -422,8 +422,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -447,8 +447,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -472,8 +472,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -497,8 +497,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -522,8 +522,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -547,8 +547,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -572,8 +572,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -597,8 +597,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -622,8 +622,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q6366077/current/popolo-m17n.json
+++ b/executive/Q6366077/current/popolo-m17n.json
@@ -69,8 +69,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -94,8 +94,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -119,8 +119,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -144,8 +144,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -169,8 +169,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -194,8 +194,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -219,8 +219,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -244,8 +244,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -269,8 +269,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -294,8 +294,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -319,8 +319,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -344,8 +344,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -369,8 +369,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -394,8 +394,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -419,8 +419,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -444,8 +444,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -469,8 +469,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -494,8 +494,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -519,8 +519,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -544,8 +544,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -569,8 +569,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -594,8 +594,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -619,8 +619,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q715055/current/popolo-m17n.json
+++ b/executive/Q715055/current/popolo-m17n.json
@@ -146,8 +146,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q7676194/current/popolo-m17n.json
+++ b/executive/Q7676194/current/popolo-m17n.json
@@ -55,8 +55,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -80,8 +80,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -105,8 +105,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -130,8 +130,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -155,8 +155,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -180,8 +180,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -205,8 +205,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -230,8 +230,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -255,8 +255,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -280,8 +280,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -305,8 +305,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -330,8 +330,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -355,8 +355,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -380,8 +380,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -405,8 +405,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -430,8 +430,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -455,8 +455,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -480,8 +480,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -505,8 +505,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -530,8 +530,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -555,8 +555,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -580,8 +580,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -605,8 +605,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/executive/Q9105560/current/popolo-m17n.json
+++ b/executive/Q9105560/current/popolo-m17n.json
@@ -58,8 +58,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -83,8 +83,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -108,8 +108,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -133,8 +133,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -158,8 +158,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -183,8 +183,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -208,8 +208,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -233,8 +233,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -258,8 +258,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -283,8 +283,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -308,8 +308,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -333,8 +333,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -358,8 +358,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -383,8 +383,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -408,8 +408,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -433,8 +433,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -458,8 +458,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -483,8 +483,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -508,8 +508,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -533,8 +533,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -558,8 +558,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -583,8 +583,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -608,8 +608,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q10907927/Q49995759/popolo-m17n.json
+++ b/legislative/Q10907927/Q49995759/popolo-m17n.json
@@ -639,7 +639,7 @@
         "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
-        "lang:zh_TW": "南投縣第01選區"
+        "lang:zh-tw": "南投縣第01選區"
       },
       "parent_id": "Q82357"
     },
@@ -663,7 +663,7 @@
         "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
-        "lang:zh_TW": "南投縣第02選區"
+        "lang:zh-tw": "南投縣第02選區"
       },
       "parent_id": "Q82357"
     },
@@ -687,7 +687,7 @@
         "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
-        "lang:zh_TW": "南投縣第03選區"
+        "lang:zh-tw": "南投縣第03選區"
       },
       "parent_id": "Q82357"
     },
@@ -711,7 +711,7 @@
         "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
-        "lang:zh_TW": "南投縣第04選區"
+        "lang:zh-tw": "南投縣第04選區"
       },
       "parent_id": "Q82357"
     },
@@ -735,7 +735,7 @@
         "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
-        "lang:zh_TW": "南投縣第05選區"
+        "lang:zh-tw": "南投縣第05選區"
       },
       "parent_id": "Q82357"
     },
@@ -759,7 +759,7 @@
         "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
-        "lang:zh_TW": "南投縣第06選區"
+        "lang:zh-tw": "南投縣第06選區"
       },
       "parent_id": "Q82357"
     },
@@ -783,7 +783,7 @@
         "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
-        "lang:zh_TW": "南投縣第07選區"
+        "lang:zh-tw": "南投縣第07選區"
       },
       "parent_id": "Q82357"
     },
@@ -807,7 +807,7 @@
         "lang:en": "Constituency of Regional Councilors of Nantou County"
       },
       "name": {
-        "lang:zh_TW": "南投縣第08選區"
+        "lang:zh-tw": "南投縣第08選區"
       },
       "parent_id": "Q82357"
     },
@@ -831,8 +831,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -856,8 +856,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q10924120/Q49995848/popolo-m17n.json
+++ b/legislative/Q10924120/Q49995848/popolo-m17n.json
@@ -445,8 +445,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -470,7 +470,7 @@
         "lang:en": "Constituency of Regional Councilors of Chiayi City"
       },
       "name": {
-        "lang:zh_TW": "嘉義市第01選區"
+        "lang:zh-tw": "嘉義市第01選區"
       },
       "parent_id": "Q249995"
     },
@@ -494,7 +494,7 @@
         "lang:en": "Constituency of Regional Councilors of Chiayi City"
       },
       "name": {
-        "lang:zh_TW": "嘉義市第02選區"
+        "lang:zh-tw": "嘉義市第02選區"
       },
       "parent_id": "Q249995"
     },
@@ -518,8 +518,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q10924150/Q49995901/popolo-m17n.json
+++ b/legislative/Q10924150/Q49995901/popolo-m17n.json
@@ -626,8 +626,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -651,7 +651,7 @@
         "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
-        "lang:zh_TW": "嘉義縣第01選區"
+        "lang:zh-tw": "嘉義縣第01選區"
       },
       "parent_id": "Q166977"
     },
@@ -675,7 +675,7 @@
         "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
-        "lang:zh_TW": "嘉義縣第02選區"
+        "lang:zh-tw": "嘉義縣第02選區"
       },
       "parent_id": "Q166977"
     },
@@ -699,7 +699,7 @@
         "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
-        "lang:zh_TW": "嘉義縣第03選區"
+        "lang:zh-tw": "嘉義縣第03選區"
       },
       "parent_id": "Q166977"
     },
@@ -723,7 +723,7 @@
         "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
-        "lang:zh_TW": "嘉義縣第04選區"
+        "lang:zh-tw": "嘉義縣第04選區"
       },
       "parent_id": "Q166977"
     },
@@ -747,7 +747,7 @@
         "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
-        "lang:zh_TW": "嘉義縣第05選區"
+        "lang:zh-tw": "嘉義縣第05選區"
       },
       "parent_id": "Q166977"
     },
@@ -771,7 +771,7 @@
         "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
-        "lang:zh_TW": "嘉義縣第06選區"
+        "lang:zh-tw": "嘉義縣第06選區"
       },
       "parent_id": "Q166977"
     },
@@ -795,7 +795,7 @@
         "lang:en": "Constituency of Regional Councilors of Chiayi County"
       },
       "name": {
-        "lang:zh_TW": "嘉義縣第07選區"
+        "lang:zh-tw": "嘉義縣第07選區"
       },
       "parent_id": "Q166977"
     },
@@ -819,8 +819,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q10930444/Q50178994/popolo-m17n.json
+++ b/legislative/Q10930444/Q50178994/popolo-m17n.json
@@ -564,8 +564,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -589,7 +589,7 @@
         "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
-        "lang:zh_TW": "基隆市第01選區"
+        "lang:zh-tw": "基隆市第01選區"
       },
       "parent_id": "Q249996"
     },
@@ -613,7 +613,7 @@
         "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
-        "lang:zh_TW": "基隆市第02選區"
+        "lang:zh-tw": "基隆市第02選區"
       },
       "parent_id": "Q249996"
     },
@@ -637,7 +637,7 @@
         "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
-        "lang:zh_TW": "基隆市第03選區"
+        "lang:zh-tw": "基隆市第03選區"
       },
       "parent_id": "Q249996"
     },
@@ -661,7 +661,7 @@
         "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
-        "lang:zh_TW": "基隆市第04選區"
+        "lang:zh-tw": "基隆市第04選區"
       },
       "parent_id": "Q249996"
     },
@@ -685,7 +685,7 @@
         "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
-        "lang:zh_TW": "基隆市第05選區"
+        "lang:zh-tw": "基隆市第05選區"
       },
       "parent_id": "Q249996"
     },
@@ -709,7 +709,7 @@
         "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
-        "lang:zh_TW": "基隆市第06選區"
+        "lang:zh-tw": "基隆市第06選區"
       },
       "parent_id": "Q249996"
     },
@@ -733,7 +733,7 @@
         "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
-        "lang:zh_TW": "基隆市第07選區"
+        "lang:zh-tw": "基隆市第07選區"
       },
       "parent_id": "Q249996"
     },
@@ -757,7 +757,7 @@
         "lang:en": "Constituency of Regional Councilors of Keelung"
       },
       "name": {
-        "lang:zh_TW": "基隆市第08選區"
+        "lang:zh-tw": "基隆市第08選區"
       },
       "parent_id": "Q249996"
     },
@@ -781,8 +781,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q11070079/Q49996108/popolo-m17n.json
+++ b/legislative/Q11070079/Q49996108/popolo-m17n.json
@@ -912,8 +912,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -937,7 +937,7 @@
         "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第01選區"
+        "lang:zh-tw": "彰化縣第01選區"
       },
       "parent_id": "Q133865"
     },
@@ -961,7 +961,7 @@
         "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第02選區"
+        "lang:zh-tw": "彰化縣第02選區"
       },
       "parent_id": "Q133865"
     },
@@ -985,7 +985,7 @@
         "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第03選區"
+        "lang:zh-tw": "彰化縣第03選區"
       },
       "parent_id": "Q133865"
     },
@@ -1009,7 +1009,7 @@
         "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第04選區"
+        "lang:zh-tw": "彰化縣第04選區"
       },
       "parent_id": "Q133865"
     },
@@ -1033,7 +1033,7 @@
         "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第05選區"
+        "lang:zh-tw": "彰化縣第05選區"
       },
       "parent_id": "Q133865"
     },
@@ -1057,7 +1057,7 @@
         "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第06選區"
+        "lang:zh-tw": "彰化縣第06選區"
       },
       "parent_id": "Q133865"
     },
@@ -1081,7 +1081,7 @@
         "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第07選區"
+        "lang:zh-tw": "彰化縣第07選區"
       },
       "parent_id": "Q133865"
     },
@@ -1105,7 +1105,7 @@
         "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第08選區"
+        "lang:zh-tw": "彰化縣第08選區"
       },
       "parent_id": "Q133865"
     },
@@ -1129,7 +1129,7 @@
         "lang:en": "Constituency of Regional Councilors of Changhua County"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第09選區"
+        "lang:zh-tw": "彰化縣第09選區"
       },
       "parent_id": "Q133865"
     },
@@ -1153,8 +1153,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q11081523/Q50167668/popolo-m17n.json
+++ b/legislative/Q11081523/Q50167668/popolo-m17n.json
@@ -1126,8 +1126,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -1151,7 +1151,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第01選區"
+        "lang:zh-tw": "新北市第01選區"
       },
       "parent_id": "Q244898"
     },
@@ -1175,7 +1175,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第02選區"
+        "lang:zh-tw": "新北市第02選區"
       },
       "parent_id": "Q244898"
     },
@@ -1199,7 +1199,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第03選區"
+        "lang:zh-tw": "新北市第03選區"
       },
       "parent_id": "Q244898"
     },
@@ -1223,7 +1223,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第04選區"
+        "lang:zh-tw": "新北市第04選區"
       },
       "parent_id": "Q244898"
     },
@@ -1247,7 +1247,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第05選區"
+        "lang:zh-tw": "新北市第05選區"
       },
       "parent_id": "Q244898"
     },
@@ -1271,7 +1271,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第06選區"
+        "lang:zh-tw": "新北市第06選區"
       },
       "parent_id": "Q244898"
     },
@@ -1295,7 +1295,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第07選區"
+        "lang:zh-tw": "新北市第07選區"
       },
       "parent_id": "Q244898"
     },
@@ -1319,7 +1319,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第08選區"
+        "lang:zh-tw": "新北市第08選區"
       },
       "parent_id": "Q244898"
     },
@@ -1343,7 +1343,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第09選區"
+        "lang:zh-tw": "新北市第09選區"
       },
       "parent_id": "Q244898"
     },
@@ -1367,7 +1367,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第10選區"
+        "lang:zh-tw": "新北市第10選區"
       },
       "parent_id": "Q244898"
     },
@@ -1391,7 +1391,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第11選區"
+        "lang:zh-tw": "新北市第11選區"
       },
       "parent_id": "Q244898"
     },
@@ -1415,7 +1415,7 @@
         "lang:en": "Constituency of Regional Councilors of New Taipei City"
       },
       "name": {
-        "lang:zh_TW": "新北市第12選區"
+        "lang:zh-tw": "新北市第12選區"
       },
       "parent_id": "Q244898"
     },
@@ -1439,8 +1439,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q11084017/Q50179034/popolo-m17n.json
+++ b/legislative/Q11084017/Q50179034/popolo-m17n.json
@@ -582,8 +582,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -607,7 +607,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
-        "lang:zh_TW": "新竹市第01選區"
+        "lang:zh-tw": "新竹市第01選區"
       },
       "parent_id": "Q249994"
     },
@@ -631,7 +631,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
-        "lang:zh_TW": "新竹市第02選區"
+        "lang:zh-tw": "新竹市第02選區"
       },
       "parent_id": "Q249994"
     },
@@ -655,7 +655,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
-        "lang:zh_TW": "新竹市第03選區"
+        "lang:zh-tw": "新竹市第03選區"
       },
       "parent_id": "Q249994"
     },
@@ -679,7 +679,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
-        "lang:zh_TW": "新竹市第04選區"
+        "lang:zh-tw": "新竹市第04選區"
       },
       "parent_id": "Q249994"
     },
@@ -703,7 +703,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
-        "lang:zh_TW": "新竹市第05選區"
+        "lang:zh-tw": "新竹市第05選區"
       },
       "parent_id": "Q249994"
     },
@@ -727,7 +727,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu"
       },
       "name": {
-        "lang:zh_TW": "新竹市第06選區"
+        "lang:zh-tw": "新竹市第06選區"
       },
       "parent_id": "Q249994"
     },
@@ -751,8 +751,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q11084065/Q49996265/popolo-m17n.json
+++ b/legislative/Q11084065/Q49996265/popolo-m17n.json
@@ -682,7 +682,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第01選區"
+        "lang:zh-tw": "新竹縣第01選區"
       },
       "parent_id": "Q74054"
     },
@@ -706,7 +706,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第02選區"
+        "lang:zh-tw": "新竹縣第02選區"
       },
       "parent_id": "Q74054"
     },
@@ -730,7 +730,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第03選區"
+        "lang:zh-tw": "新竹縣第03選區"
       },
       "parent_id": "Q74054"
     },
@@ -754,7 +754,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第04選區"
+        "lang:zh-tw": "新竹縣第04選區"
       },
       "parent_id": "Q74054"
     },
@@ -778,7 +778,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第05選區"
+        "lang:zh-tw": "新竹縣第05選區"
       },
       "parent_id": "Q74054"
     },
@@ -802,7 +802,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第06選區"
+        "lang:zh-tw": "新竹縣第06選區"
       },
       "parent_id": "Q74054"
     },
@@ -826,7 +826,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第07選區"
+        "lang:zh-tw": "新竹縣第07選區"
       },
       "parent_id": "Q74054"
     },
@@ -850,7 +850,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第08選區"
+        "lang:zh-tw": "新竹縣第08選區"
       },
       "parent_id": "Q74054"
     },
@@ -874,7 +874,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第09選區"
+        "lang:zh-tw": "新竹縣第09選區"
       },
       "parent_id": "Q74054"
     },
@@ -898,7 +898,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第10選區"
+        "lang:zh-tw": "新竹縣第10選區"
       },
       "parent_id": "Q74054"
     },
@@ -922,7 +922,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第11選區"
+        "lang:zh-tw": "新竹縣第11選區"
       },
       "parent_id": "Q74054"
     },
@@ -946,7 +946,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第12選區"
+        "lang:zh-tw": "新竹縣第12選區"
       },
       "parent_id": "Q74054"
     },
@@ -970,7 +970,7 @@
         "lang:en": "Constituency of Regional Councilors of Hsinchu County"
       },
       "name": {
-        "lang:zh_TW": "新竹縣第13選區"
+        "lang:zh-tw": "新竹縣第13選區"
       },
       "parent_id": "Q74054"
     },
@@ -994,8 +994,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -1019,8 +1019,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q11112210/Q49996297/popolo-m17n.json
+++ b/legislative/Q11112210/Q49996297/popolo-m17n.json
@@ -1016,8 +1016,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -1041,7 +1041,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第01選區"
+        "lang:zh-tw": "桃園市第01選區"
       },
       "parent_id": "Q115256"
     },
@@ -1065,7 +1065,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第02選區"
+        "lang:zh-tw": "桃園市第02選區"
       },
       "parent_id": "Q115256"
     },
@@ -1089,7 +1089,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第03選區"
+        "lang:zh-tw": "桃園市第03選區"
       },
       "parent_id": "Q115256"
     },
@@ -1113,7 +1113,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第04選區"
+        "lang:zh-tw": "桃園市第04選區"
       },
       "parent_id": "Q115256"
     },
@@ -1137,7 +1137,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第05選區"
+        "lang:zh-tw": "桃園市第05選區"
       },
       "parent_id": "Q115256"
     },
@@ -1161,7 +1161,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第06選區"
+        "lang:zh-tw": "桃園市第06選區"
       },
       "parent_id": "Q115256"
     },
@@ -1185,7 +1185,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第07選區"
+        "lang:zh-tw": "桃園市第07選區"
       },
       "parent_id": "Q115256"
     },
@@ -1209,7 +1209,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第08選區"
+        "lang:zh-tw": "桃園市第08選區"
       },
       "parent_id": "Q115256"
     },
@@ -1233,7 +1233,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第09選區"
+        "lang:zh-tw": "桃園市第09選區"
       },
       "parent_id": "Q115256"
     },
@@ -1257,7 +1257,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第10選區"
+        "lang:zh-tw": "桃園市第10選區"
       },
       "parent_id": "Q115256"
     },
@@ -1281,7 +1281,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第11選區"
+        "lang:zh-tw": "桃園市第11選區"
       },
       "parent_id": "Q115256"
     },
@@ -1305,7 +1305,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第12選區"
+        "lang:zh-tw": "桃園市第12選區"
       },
       "parent_id": "Q115256"
     },
@@ -1329,7 +1329,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第13選區"
+        "lang:zh-tw": "桃園市第13選區"
       },
       "parent_id": "Q115256"
     },
@@ -1353,7 +1353,7 @@
         "lang:en": "Constituency of Regional Councilors of Taoyuan City"
       },
       "name": {
-        "lang:zh_TW": "桃園市第14選區"
+        "lang:zh-tw": "桃園市第14選區"
       },
       "parent_id": "Q115256"
     },
@@ -1377,8 +1377,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q15899378/Q49996566/popolo-m17n.json
+++ b/legislative/Q15899378/Q49996566/popolo-m17n.json
@@ -1084,8 +1084,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -1109,7 +1109,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第01選區"
+        "lang:zh-tw": "臺中市第01選區"
       },
       "parent_id": "Q245023"
     },
@@ -1133,7 +1133,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第02選區"
+        "lang:zh-tw": "臺中市第02選區"
       },
       "parent_id": "Q245023"
     },
@@ -1157,7 +1157,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第03選區"
+        "lang:zh-tw": "臺中市第03選區"
       },
       "parent_id": "Q245023"
     },
@@ -1181,7 +1181,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第04選區"
+        "lang:zh-tw": "臺中市第04選區"
       },
       "parent_id": "Q245023"
     },
@@ -1205,7 +1205,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第05選區"
+        "lang:zh-tw": "臺中市第05選區"
       },
       "parent_id": "Q245023"
     },
@@ -1229,7 +1229,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第06選區"
+        "lang:zh-tw": "臺中市第06選區"
       },
       "parent_id": "Q245023"
     },
@@ -1253,7 +1253,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第07選區"
+        "lang:zh-tw": "臺中市第07選區"
       },
       "parent_id": "Q245023"
     },
@@ -1277,7 +1277,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第08選區"
+        "lang:zh-tw": "臺中市第08選區"
       },
       "parent_id": "Q245023"
     },
@@ -1301,7 +1301,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第09選區"
+        "lang:zh-tw": "臺中市第09選區"
       },
       "parent_id": "Q245023"
     },
@@ -1325,7 +1325,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第10選區"
+        "lang:zh-tw": "臺中市第10選區"
       },
       "parent_id": "Q245023"
     },
@@ -1349,7 +1349,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第11選區"
+        "lang:zh-tw": "臺中市第11選區"
       },
       "parent_id": "Q245023"
     },
@@ -1373,7 +1373,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第12選區"
+        "lang:zh-tw": "臺中市第12選區"
       },
       "parent_id": "Q245023"
     },
@@ -1397,7 +1397,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第13選區"
+        "lang:zh-tw": "臺中市第13選區"
       },
       "parent_id": "Q245023"
     },
@@ -1421,7 +1421,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第14選區"
+        "lang:zh-tw": "臺中市第14選區"
       },
       "parent_id": "Q245023"
     },
@@ -1445,7 +1445,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第15選區"
+        "lang:zh-tw": "臺中市第15選區"
       },
       "parent_id": "Q245023"
     },
@@ -1469,7 +1469,7 @@
         "lang:en": "Constituency of Regional Councilors of Taichung"
       },
       "name": {
-        "lang:zh_TW": "臺中市第16選區"
+        "lang:zh-tw": "臺中市第16選區"
       },
       "parent_id": "Q245023"
     },
@@ -1493,8 +1493,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q15903185/Q49996052/popolo-m17n.json
+++ b/legislative/Q15903185/Q49996052/popolo-m17n.json
@@ -943,8 +943,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -968,7 +968,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第01選區"
+        "lang:zh-tw": "屏東縣第01選區"
       },
       "parent_id": "Q194989"
     },
@@ -992,7 +992,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第02選區"
+        "lang:zh-tw": "屏東縣第02選區"
       },
       "parent_id": "Q194989"
     },
@@ -1016,7 +1016,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第03選區"
+        "lang:zh-tw": "屏東縣第03選區"
       },
       "parent_id": "Q194989"
     },
@@ -1040,7 +1040,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第04選區"
+        "lang:zh-tw": "屏東縣第04選區"
       },
       "parent_id": "Q194989"
     },
@@ -1064,7 +1064,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第05選區"
+        "lang:zh-tw": "屏東縣第05選區"
       },
       "parent_id": "Q194989"
     },
@@ -1088,7 +1088,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第06選區"
+        "lang:zh-tw": "屏東縣第06選區"
       },
       "parent_id": "Q194989"
     },
@@ -1112,7 +1112,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第07選區"
+        "lang:zh-tw": "屏東縣第07選區"
       },
       "parent_id": "Q194989"
     },
@@ -1136,7 +1136,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第08選區"
+        "lang:zh-tw": "屏東縣第08選區"
       },
       "parent_id": "Q194989"
     },
@@ -1160,7 +1160,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第09選區"
+        "lang:zh-tw": "屏東縣第09選區"
       },
       "parent_id": "Q194989"
     },
@@ -1184,7 +1184,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第10選區"
+        "lang:zh-tw": "屏東縣第10選區"
       },
       "parent_id": "Q194989"
     },
@@ -1208,7 +1208,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第11選區"
+        "lang:zh-tw": "屏東縣第11選區"
       },
       "parent_id": "Q194989"
     },
@@ -1232,7 +1232,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第12選區"
+        "lang:zh-tw": "屏東縣第12選區"
       },
       "parent_id": "Q194989"
     },
@@ -1256,7 +1256,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第13選區"
+        "lang:zh-tw": "屏東縣第13選區"
       },
       "parent_id": "Q194989"
     },
@@ -1280,7 +1280,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第14選區"
+        "lang:zh-tw": "屏東縣第14選區"
       },
       "parent_id": "Q194989"
     },
@@ -1304,7 +1304,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第15選區"
+        "lang:zh-tw": "屏東縣第15選區"
       },
       "parent_id": "Q194989"
     },
@@ -1328,7 +1328,7 @@
         "lang:en": "Constituency of Regional Councilors of Pingtung County"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第16選區"
+        "lang:zh-tw": "屏東縣第16選區"
       },
       "parent_id": "Q194989"
     },
@@ -1352,8 +1352,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q15904162/Q49996626/popolo-m17n.json
+++ b/legislative/Q15904162/Q49996626/popolo-m17n.json
@@ -716,7 +716,7 @@
         "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
-        "lang:zh_TW": "苗栗縣第01選區"
+        "lang:zh-tw": "苗栗縣第01選區"
       },
       "parent_id": "Q63706"
     },
@@ -740,7 +740,7 @@
         "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
-        "lang:zh_TW": "苗栗縣第02選區"
+        "lang:zh-tw": "苗栗縣第02選區"
       },
       "parent_id": "Q63706"
     },
@@ -764,7 +764,7 @@
         "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
-        "lang:zh_TW": "苗栗縣第03選區"
+        "lang:zh-tw": "苗栗縣第03選區"
       },
       "parent_id": "Q63706"
     },
@@ -788,7 +788,7 @@
         "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
-        "lang:zh_TW": "苗栗縣第04選區"
+        "lang:zh-tw": "苗栗縣第04選區"
       },
       "parent_id": "Q63706"
     },
@@ -812,7 +812,7 @@
         "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
-        "lang:zh_TW": "苗栗縣第05選區"
+        "lang:zh-tw": "苗栗縣第05選區"
       },
       "parent_id": "Q63706"
     },
@@ -836,7 +836,7 @@
         "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
-        "lang:zh_TW": "苗栗縣第06選區"
+        "lang:zh-tw": "苗栗縣第06選區"
       },
       "parent_id": "Q63706"
     },
@@ -860,7 +860,7 @@
         "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
-        "lang:zh_TW": "苗栗縣第07選區"
+        "lang:zh-tw": "苗栗縣第07選區"
       },
       "parent_id": "Q63706"
     },
@@ -884,7 +884,7 @@
         "lang:en": "Constituency of Regional Councilors of Miaoli County"
       },
       "name": {
-        "lang:zh_TW": "苗栗縣第08選區"
+        "lang:zh-tw": "苗栗縣第08選區"
       },
       "parent_id": "Q63706"
     },
@@ -908,8 +908,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -933,8 +933,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q15908339/Q50179059/popolo-m17n.json
+++ b/legislative/Q15908339/Q50179059/popolo-m17n.json
@@ -566,8 +566,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -591,7 +591,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第01選區"
+        "lang:zh-tw": "臺東縣第01選區"
       },
       "parent_id": "Q249904"
     },
@@ -615,7 +615,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第02選區"
+        "lang:zh-tw": "臺東縣第02選區"
       },
       "parent_id": "Q249904"
     },
@@ -639,7 +639,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第03選區"
+        "lang:zh-tw": "臺東縣第03選區"
       },
       "parent_id": "Q249904"
     },
@@ -663,7 +663,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第04選區"
+        "lang:zh-tw": "臺東縣第04選區"
       },
       "parent_id": "Q249904"
     },
@@ -687,7 +687,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第05選區"
+        "lang:zh-tw": "臺東縣第05選區"
       },
       "parent_id": "Q249904"
     },
@@ -711,7 +711,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第06選區"
+        "lang:zh-tw": "臺東縣第06選區"
       },
       "parent_id": "Q249904"
     },
@@ -735,7 +735,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第07選區"
+        "lang:zh-tw": "臺東縣第07選區"
       },
       "parent_id": "Q249904"
     },
@@ -759,7 +759,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第08選區"
+        "lang:zh-tw": "臺東縣第08選區"
       },
       "parent_id": "Q249904"
     },
@@ -783,7 +783,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第09選區"
+        "lang:zh-tw": "臺東縣第09選區"
       },
       "parent_id": "Q249904"
     },
@@ -807,7 +807,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第10選區"
+        "lang:zh-tw": "臺東縣第10選區"
       },
       "parent_id": "Q249904"
     },
@@ -831,7 +831,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第11選區"
+        "lang:zh-tw": "臺東縣第11選區"
       },
       "parent_id": "Q249904"
     },
@@ -855,7 +855,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第12選區"
+        "lang:zh-tw": "臺東縣第12選區"
       },
       "parent_id": "Q249904"
     },
@@ -879,7 +879,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第13選區"
+        "lang:zh-tw": "臺東縣第13選區"
       },
       "parent_id": "Q249904"
     },
@@ -903,7 +903,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第14選區"
+        "lang:zh-tw": "臺東縣第14選區"
       },
       "parent_id": "Q249904"
     },
@@ -927,7 +927,7 @@
         "lang:en": "Constituency of Regional Councilors of Taitung County"
       },
       "name": {
-        "lang:zh_TW": "臺東縣第15選區"
+        "lang:zh-tw": "臺東縣第15選區"
       },
       "parent_id": "Q249904"
     },
@@ -951,8 +951,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q15908941/Q49996733/popolo-m17n.json
+++ b/legislative/Q15908941/Q49996733/popolo-m17n.json
@@ -748,8 +748,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -773,7 +773,7 @@
         "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
-        "lang:zh_TW": "雲林縣第01選區"
+        "lang:zh-tw": "雲林縣第01選區"
       },
       "parent_id": "Q153221"
     },
@@ -797,7 +797,7 @@
         "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
-        "lang:zh_TW": "雲林縣第02選區"
+        "lang:zh-tw": "雲林縣第02選區"
       },
       "parent_id": "Q153221"
     },
@@ -821,7 +821,7 @@
         "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
-        "lang:zh_TW": "雲林縣第03選區"
+        "lang:zh-tw": "雲林縣第03選區"
       },
       "parent_id": "Q153221"
     },
@@ -845,7 +845,7 @@
         "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
-        "lang:zh_TW": "雲林縣第04選區"
+        "lang:zh-tw": "雲林縣第04選區"
       },
       "parent_id": "Q153221"
     },
@@ -869,7 +869,7 @@
         "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
-        "lang:zh_TW": "雲林縣第05選區"
+        "lang:zh-tw": "雲林縣第05選區"
       },
       "parent_id": "Q153221"
     },
@@ -893,7 +893,7 @@
         "lang:en": "Constituency of Regional Councilors of Yunlin County"
       },
       "name": {
-        "lang:zh_TW": "雲林縣第06選區"
+        "lang:zh-tw": "雲林縣第06選區"
       },
       "parent_id": "Q153221"
     },
@@ -917,8 +917,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q15909148/Q49995992/popolo-m17n.json
+++ b/legislative/Q15909148/Q49995992/popolo-m17n.json
@@ -611,8 +611,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -636,7 +636,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第01選區"
+        "lang:zh-tw": "宜蘭縣第01選區"
       },
       "parent_id": "Q237258"
     },
@@ -660,7 +660,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第02選區"
+        "lang:zh-tw": "宜蘭縣第02選區"
       },
       "parent_id": "Q237258"
     },
@@ -684,7 +684,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第03選區"
+        "lang:zh-tw": "宜蘭縣第03選區"
       },
       "parent_id": "Q237258"
     },
@@ -708,7 +708,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第04選區"
+        "lang:zh-tw": "宜蘭縣第04選區"
       },
       "parent_id": "Q237258"
     },
@@ -732,7 +732,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第05選區"
+        "lang:zh-tw": "宜蘭縣第05選區"
       },
       "parent_id": "Q237258"
     },
@@ -756,7 +756,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第06選區"
+        "lang:zh-tw": "宜蘭縣第06選區"
       },
       "parent_id": "Q237258"
     },
@@ -780,7 +780,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第07選區"
+        "lang:zh-tw": "宜蘭縣第07選區"
       },
       "parent_id": "Q237258"
     },
@@ -804,7 +804,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第08選區"
+        "lang:zh-tw": "宜蘭縣第08選區"
       },
       "parent_id": "Q237258"
     },
@@ -828,7 +828,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第09選區"
+        "lang:zh-tw": "宜蘭縣第09選區"
       },
       "parent_id": "Q237258"
     },
@@ -852,7 +852,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第10選區"
+        "lang:zh-tw": "宜蘭縣第10選區"
       },
       "parent_id": "Q237258"
     },
@@ -876,7 +876,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第11選區"
+        "lang:zh-tw": "宜蘭縣第11選區"
       },
       "parent_id": "Q237258"
     },
@@ -900,7 +900,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第12選區"
+        "lang:zh-tw": "宜蘭縣第12選區"
       },
       "parent_id": "Q237258"
     },
@@ -924,7 +924,7 @@
         "lang:en": "Constituency of Regional Councilors of Yilan County"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣第13選區"
+        "lang:zh-tw": "宜蘭縣第13選區"
       },
       "parent_id": "Q237258"
     },
@@ -948,8 +948,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q15909304/Q49996593/popolo-m17n.json
+++ b/legislative/Q15909304/Q49996593/popolo-m17n.json
@@ -567,8 +567,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -592,7 +592,7 @@
         "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣第01選區"
+        "lang:zh-tw": "花蓮縣第01選區"
       },
       "parent_id": "Q249868"
     },
@@ -616,7 +616,7 @@
         "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣第02選區"
+        "lang:zh-tw": "花蓮縣第02選區"
       },
       "parent_id": "Q249868"
     },
@@ -640,7 +640,7 @@
         "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣第03選區"
+        "lang:zh-tw": "花蓮縣第03選區"
       },
       "parent_id": "Q249868"
     },
@@ -664,7 +664,7 @@
         "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣第04選區"
+        "lang:zh-tw": "花蓮縣第04選區"
       },
       "parent_id": "Q249868"
     },
@@ -688,7 +688,7 @@
         "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣第05選區"
+        "lang:zh-tw": "花蓮縣第05選區"
       },
       "parent_id": "Q249868"
     },
@@ -712,7 +712,7 @@
         "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣第06選區"
+        "lang:zh-tw": "花蓮縣第06選區"
       },
       "parent_id": "Q249868"
     },
@@ -736,7 +736,7 @@
         "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣第07選區"
+        "lang:zh-tw": "花蓮縣第07選區"
       },
       "parent_id": "Q249868"
     },
@@ -760,7 +760,7 @@
         "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣第08選區"
+        "lang:zh-tw": "花蓮縣第08選區"
       },
       "parent_id": "Q249868"
     },
@@ -784,7 +784,7 @@
         "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣第09選區"
+        "lang:zh-tw": "花蓮縣第09選區"
       },
       "parent_id": "Q249868"
     },
@@ -808,7 +808,7 @@
         "lang:en": "Constituency of Regional Councilors of Hualien County"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣第10選區"
+        "lang:zh-tw": "花蓮縣第10選區"
       },
       "parent_id": "Q249868"
     },
@@ -832,8 +832,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q15914537/Q49996694/popolo-m17n.json
+++ b/legislative/Q15914537/Q49996694/popolo-m17n.json
@@ -402,8 +402,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -427,7 +427,7 @@
         "lang:en": "Constituency of Regional Councilors of Kinmen"
       },
       "name": {
-        "lang:zh_TW": "金門縣第01選區"
+        "lang:zh-tw": "金門縣第01選區"
       },
       "parent_id": "Q249870"
     },
@@ -451,7 +451,7 @@
         "lang:en": "Constituency of Regional Councilors of Kinmen"
       },
       "name": {
-        "lang:zh_TW": "金門縣第02選區"
+        "lang:zh-tw": "金門縣第02選區"
       },
       "parent_id": "Q249870"
     },
@@ -475,7 +475,7 @@
         "lang:en": "Constituency of Regional Councilors of Kinmen"
       },
       "name": {
-        "lang:zh_TW": "金門縣第03選區"
+        "lang:zh-tw": "金門縣第03選區"
       },
       "parent_id": "Q249870"
     },
@@ -499,8 +499,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q15915051/Q49996554/popolo-m17n.json
+++ b/legislative/Q15915051/Q49996554/popolo-m17n.json
@@ -431,8 +431,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -456,7 +456,7 @@
         "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
-        "lang:zh_TW": "澎湖縣第01選區"
+        "lang:zh-tw": "澎湖縣第01選區"
       },
       "parent_id": "Q198525"
     },
@@ -480,7 +480,7 @@
         "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
-        "lang:zh_TW": "澎湖縣第02選區"
+        "lang:zh-tw": "澎湖縣第02選區"
       },
       "parent_id": "Q198525"
     },
@@ -504,7 +504,7 @@
         "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
-        "lang:zh_TW": "澎湖縣第03選區"
+        "lang:zh-tw": "澎湖縣第03選區"
       },
       "parent_id": "Q198525"
     },
@@ -528,7 +528,7 @@
         "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
-        "lang:zh_TW": "澎湖縣第04選區"
+        "lang:zh-tw": "澎湖縣第04選區"
       },
       "parent_id": "Q198525"
     },
@@ -552,7 +552,7 @@
         "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
-        "lang:zh_TW": "澎湖縣第05選區"
+        "lang:zh-tw": "澎湖縣第05選區"
       },
       "parent_id": "Q198525"
     },
@@ -576,7 +576,7 @@
         "lang:en": "Constituency of Regional Councilors of Penghu County"
       },
       "name": {
-        "lang:zh_TW": "澎湖縣第06選區"
+        "lang:zh-tw": "澎湖縣第06選區"
       },
       "parent_id": "Q198525"
     },
@@ -600,8 +600,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q15919452/Q49996660/popolo-m17n.json
+++ b/legislative/Q15919452/Q49996660/popolo-m17n.json
@@ -191,8 +191,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -216,7 +216,7 @@
         "lang:en": "Constituency of Regional Councilors of Lienchiang County"
       },
       "name": {
-        "lang:zh_TW": "連江縣第01選區"
+        "lang:zh-tw": "連江縣第01選區"
       },
       "parent_id": "Q249872"
     },
@@ -240,7 +240,7 @@
         "lang:en": "Constituency of Regional Councilors of Lienchiang County"
       },
       "name": {
-        "lang:zh_TW": "連江縣第02選區"
+        "lang:zh-tw": "連江縣第02選區"
       },
       "parent_id": "Q249872"
     },
@@ -264,7 +264,7 @@
         "lang:en": "Constituency of Regional Councilors of Lienchiang County"
       },
       "name": {
-        "lang:zh_TW": "連江縣第03選區"
+        "lang:zh-tw": "連江縣第03選區"
       },
       "parent_id": "Q249872"
     },
@@ -288,7 +288,7 @@
         "lang:en": "Constituency of Regional Councilors of Lienchiang County"
       },
       "name": {
-        "lang:zh_TW": "連江縣第04選區"
+        "lang:zh-tw": "連江縣第04選區"
       },
       "parent_id": "Q249872"
     },
@@ -312,8 +312,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q6366073/Q49996760/popolo-m17n.json
+++ b/legislative/Q6366073/Q49996760/popolo-m17n.json
@@ -1153,8 +1153,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -1178,7 +1178,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第01選區"
+        "lang:zh-tw": "高雄市第01選區"
       },
       "parent_id": "Q181557"
     },
@@ -1202,7 +1202,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第02選區"
+        "lang:zh-tw": "高雄市第02選區"
       },
       "parent_id": "Q181557"
     },
@@ -1226,7 +1226,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第03選區"
+        "lang:zh-tw": "高雄市第03選區"
       },
       "parent_id": "Q181557"
     },
@@ -1250,7 +1250,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第04選區"
+        "lang:zh-tw": "高雄市第04選區"
       },
       "parent_id": "Q181557"
     },
@@ -1274,7 +1274,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第05選區"
+        "lang:zh-tw": "高雄市第05選區"
       },
       "parent_id": "Q181557"
     },
@@ -1298,7 +1298,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第06選區"
+        "lang:zh-tw": "高雄市第06選區"
       },
       "parent_id": "Q181557"
     },
@@ -1322,7 +1322,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第07選區"
+        "lang:zh-tw": "高雄市第07選區"
       },
       "parent_id": "Q181557"
     },
@@ -1346,7 +1346,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第08選區"
+        "lang:zh-tw": "高雄市第08選區"
       },
       "parent_id": "Q181557"
     },
@@ -1370,7 +1370,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第09選區"
+        "lang:zh-tw": "高雄市第09選區"
       },
       "parent_id": "Q181557"
     },
@@ -1394,7 +1394,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第10選區"
+        "lang:zh-tw": "高雄市第10選區"
       },
       "parent_id": "Q181557"
     },
@@ -1418,7 +1418,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第11選區"
+        "lang:zh-tw": "高雄市第11選區"
       },
       "parent_id": "Q181557"
     },
@@ -1442,7 +1442,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第12選區"
+        "lang:zh-tw": "高雄市第12選區"
       },
       "parent_id": "Q181557"
     },
@@ -1466,7 +1466,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第13選區"
+        "lang:zh-tw": "高雄市第13選區"
       },
       "parent_id": "Q181557"
     },
@@ -1490,7 +1490,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第14選區"
+        "lang:zh-tw": "高雄市第14選區"
       },
       "parent_id": "Q181557"
     },
@@ -1514,7 +1514,7 @@
         "lang:en": "Constituency of Regional Councilors of Kaohsiung City"
       },
       "name": {
-        "lang:zh_TW": "高雄市第15選區"
+        "lang:zh-tw": "高雄市第15選區"
       },
       "parent_id": "Q181557"
     },
@@ -1538,8 +1538,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q715869/Q22083907/popolo-m17n.json
+++ b/legislative/Q715869/Q22083907/popolo-m17n.json
@@ -1985,7 +1985,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "南投縣第二選舉區"
+        "lang:zh-tw": "南投縣第二選舉區"
       },
       "parent_id": "Q82357"
     },
@@ -2009,7 +2009,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "嘉義市選舉區"
+        "lang:zh-tw": "嘉義市選舉區"
       },
       "parent_id": "Q249995"
     },
@@ -2033,7 +2033,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "宜蘭縣選舉區"
+        "lang:zh-tw": "宜蘭縣選舉區"
       },
       "parent_id": "Q237258"
     },
@@ -2057,7 +2057,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第一選舉區"
+        "lang:zh-tw": "屏東縣第一選舉區"
       },
       "parent_id": "Q194989"
     },
@@ -2081,7 +2081,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新竹市選舉區"
+        "lang:zh-tw": "新竹市選舉區"
       },
       "parent_id": "Q249994"
     },
@@ -2105,7 +2105,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新竹縣選舉區"
+        "lang:zh-tw": "新竹縣選舉區"
       },
       "parent_id": "Q74054"
     },
@@ -2129,7 +2129,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "桃園市第一選舉區"
+        "lang:zh-tw": "桃園市第一選舉區"
       },
       "parent_id": "Q115256"
     },
@@ -2153,7 +2153,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "桃園市第三選舉區"
+        "lang:zh-tw": "桃園市第三選舉區"
       },
       "parent_id": "Q115256"
     },
@@ -2177,7 +2177,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "桃園市第二選舉區"
+        "lang:zh-tw": "桃園市第二選舉區"
       },
       "parent_id": "Q115256"
     },
@@ -2201,7 +2201,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "桃園市第五選舉區"
+        "lang:zh-tw": "桃園市第五選舉區"
       },
       "parent_id": "Q115256"
     },
@@ -2225,7 +2225,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "桃園市第六選舉區"
+        "lang:zh-tw": "桃園市第六選舉區"
       },
       "parent_id": "Q115256"
     },
@@ -2249,7 +2249,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "桃園市第四選舉區"
+        "lang:zh-tw": "桃園市第四選舉區"
       },
       "parent_id": "Q115256"
     },
@@ -2273,8 +2273,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taoyuan City",
-        "lang:zh_TW": "桃園市"
+        "lang:en": "Taoyuan City",
+        "lang:zh-tw": "桃園市"
       },
       "parent_id": "Q865"
     },
@@ -2298,8 +2298,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Changhua County",
-        "lang:zh_TW": "彰化縣"
+        "lang:en": "Changhua County",
+        "lang:zh-tw": "彰化縣"
       },
       "parent_id": "Q865"
     },
@@ -2323,8 +2323,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -2348,7 +2348,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺北市第一選舉區"
+        "lang:zh-tw": "臺北市第一選舉區"
       },
       "parent_id": "Q1867"
     },
@@ -2372,8 +2372,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yunlin County",
-        "lang:zh_TW": "雲林縣"
+        "lang:en": "Yunlin County",
+        "lang:zh-tw": "雲林縣"
       },
       "parent_id": "Q865"
     },
@@ -2397,7 +2397,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺中市第四選舉區"
+        "lang:zh-tw": "臺中市第四選舉區"
       },
       "parent_id": "Q245023"
     },
@@ -2421,7 +2421,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺中市第一選舉區"
+        "lang:zh-tw": "臺中市第一選舉區"
       },
       "parent_id": "Q245023"
     },
@@ -2445,7 +2445,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺中市第二選舉區"
+        "lang:zh-tw": "臺中市第二選舉區"
       },
       "parent_id": "Q245023"
     },
@@ -2469,7 +2469,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺中市第三選舉區"
+        "lang:zh-tw": "臺中市第三選舉區"
       },
       "parent_id": "Q245023"
     },
@@ -2493,7 +2493,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "苗栗縣第一選舉區"
+        "lang:zh-tw": "苗栗縣第一選舉區"
       },
       "parent_id": "Q63706"
     },
@@ -2517,7 +2517,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "苗栗縣第二選舉區"
+        "lang:zh-tw": "苗栗縣第二選舉區"
       },
       "parent_id": "Q63706"
     },
@@ -2541,7 +2541,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺北市第四選舉區"
+        "lang:zh-tw": "臺北市第四選舉區"
       },
       "parent_id": "Q1867"
     },
@@ -2565,7 +2565,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺南市第一選舉區"
+        "lang:zh-tw": "臺南市第一選舉區"
       },
       "parent_id": "Q140631"
     },
@@ -2589,8 +2589,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Chiayi County",
-        "lang:zh_TW": "嘉義縣"
+        "lang:en": "Chiayi County",
+        "lang:zh-tw": "嘉義縣"
       },
       "parent_id": "Q865"
     },
@@ -2614,7 +2614,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺北市第七選舉區"
+        "lang:zh-tw": "臺北市第七選舉區"
       },
       "parent_id": "Q1867"
     },
@@ -2638,7 +2638,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺北市第三選舉區"
+        "lang:zh-tw": "臺北市第三選舉區"
       },
       "parent_id": "Q1867"
     },
@@ -2662,7 +2662,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺北市第二選舉區"
+        "lang:zh-tw": "臺北市第二選舉區"
       },
       "parent_id": "Q1867"
     },
@@ -2686,7 +2686,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺北市第五選舉區"
+        "lang:zh-tw": "臺北市第五選舉區"
       },
       "parent_id": "Q1867"
     },
@@ -2710,7 +2710,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺北市第八選舉區"
+        "lang:zh-tw": "臺北市第八選舉區"
       },
       "parent_id": "Q1867"
     },
@@ -2734,7 +2734,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺北市第六選舉區"
+        "lang:zh-tw": "臺北市第六選舉區"
       },
       "parent_id": "Q1867"
     },
@@ -2758,7 +2758,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺南市第五選舉區"
+        "lang:zh-tw": "臺南市第五選舉區"
       },
       "parent_id": "Q140631"
     },
@@ -2782,7 +2782,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第一選舉區"
+        "lang:zh-tw": "新北市第一選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -2806,7 +2806,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第七選舉區"
+        "lang:zh-tw": "新北市第七選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -2830,7 +2830,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第三選舉區"
+        "lang:zh-tw": "新北市第三選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -2854,7 +2854,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第九選舉區"
+        "lang:zh-tw": "新北市第九選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -2878,7 +2878,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第五選舉區"
+        "lang:zh-tw": "新北市第五選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -2902,7 +2902,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第六選舉區"
+        "lang:zh-tw": "新北市第六選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -2926,7 +2926,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第十一選舉區"
+        "lang:zh-tw": "新北市第十一選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -2950,7 +2950,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第十二選舉區"
+        "lang:zh-tw": "新北市第十二選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -2974,7 +2974,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第十選舉區"
+        "lang:zh-tw": "新北市第十選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -2998,7 +2998,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第四選舉區"
+        "lang:zh-tw": "新北市第四選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -3022,7 +3022,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺中市第七選舉區"
+        "lang:zh-tw": "臺中市第七選舉區"
       },
       "parent_id": "Q245023"
     },
@@ -3046,7 +3046,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺中市第五選舉區"
+        "lang:zh-tw": "臺中市第五選舉區"
       },
       "parent_id": "Q245023"
     },
@@ -3070,7 +3070,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺中市第八選舉區"
+        "lang:zh-tw": "臺中市第八選舉區"
       },
       "parent_id": "Q245023"
     },
@@ -3094,7 +3094,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺中市第六選舉區"
+        "lang:zh-tw": "臺中市第六選舉區"
       },
       "parent_id": "Q245023"
     },
@@ -3118,7 +3118,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺南市第三選舉區"
+        "lang:zh-tw": "臺南市第三選舉區"
       },
       "parent_id": "Q140631"
     },
@@ -3142,7 +3142,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺南市第四選舉區"
+        "lang:zh-tw": "臺南市第四選舉區"
       },
       "parent_id": "Q140631"
     },
@@ -3166,7 +3166,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "高雄市第一選舉區"
+        "lang:zh-tw": "高雄市第一選舉區"
       },
       "parent_id": "Q181557"
     },
@@ -3190,7 +3190,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "高雄市第七選舉區"
+        "lang:zh-tw": "高雄市第七選舉區"
       },
       "parent_id": "Q181557"
     },
@@ -3214,7 +3214,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "高雄市第三選舉區"
+        "lang:zh-tw": "高雄市第三選舉區"
       },
       "parent_id": "Q181557"
     },
@@ -3238,7 +3238,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "高雄市第九選舉區"
+        "lang:zh-tw": "高雄市第九選舉區"
       },
       "parent_id": "Q181557"
     },
@@ -3262,7 +3262,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "高雄市第二選舉區"
+        "lang:zh-tw": "高雄市第二選舉區"
       },
       "parent_id": "Q181557"
     },
@@ -3286,7 +3286,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "高雄市第五選舉區"
+        "lang:zh-tw": "高雄市第五選舉區"
       },
       "parent_id": "Q181557"
     },
@@ -3310,7 +3310,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "高雄市第八選舉區"
+        "lang:zh-tw": "高雄市第八選舉區"
       },
       "parent_id": "Q181557"
     },
@@ -3334,7 +3334,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "高雄市第六選舉區"
+        "lang:zh-tw": "高雄市第六選舉區"
       },
       "parent_id": "Q181557"
     },
@@ -3358,7 +3358,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "高雄市第四選舉區"
+        "lang:zh-tw": "高雄市第四選舉區"
       },
       "parent_id": "Q181557"
     },
@@ -3382,7 +3382,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺南市第二選舉區"
+        "lang:zh-tw": "臺南市第二選舉區"
       },
       "parent_id": "Q140631"
     },
@@ -3406,7 +3406,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "嘉義縣第一選舉區"
+        "lang:zh-tw": "嘉義縣第一選舉區"
       },
       "parent_id": "Q166977"
     },
@@ -3430,7 +3430,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "嘉義縣第二選舉區"
+        "lang:zh-tw": "嘉義縣第二選舉區"
       },
       "parent_id": "Q166977"
     },
@@ -3454,7 +3454,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "基隆市選舉區"
+        "lang:zh-tw": "基隆市選舉區"
       },
       "parent_id": "Q249996"
     },
@@ -3478,7 +3478,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第三選舉區"
+        "lang:zh-tw": "屏東縣第三選舉區"
       },
       "parent_id": "Q194989"
     },
@@ -3502,7 +3502,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "屏東縣第二選舉區"
+        "lang:zh-tw": "屏東縣第二選舉區"
       },
       "parent_id": "Q194989"
     },
@@ -3526,7 +3526,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第一選舉區"
+        "lang:zh-tw": "彰化縣第一選舉區"
       },
       "parent_id": "Q133865"
     },
@@ -3550,7 +3550,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第二選舉區"
+        "lang:zh-tw": "彰化縣第二選舉區"
       },
       "parent_id": "Q133865"
     },
@@ -3574,7 +3574,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第三選舉區"
+        "lang:zh-tw": "彰化縣第三選舉區"
       },
       "parent_id": "Q133865"
     },
@@ -3598,7 +3598,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "彰化縣第四選舉區"
+        "lang:zh-tw": "彰化縣第四選舉區"
       },
       "parent_id": "Q133865"
     },
@@ -3622,7 +3622,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第二選舉區"
+        "lang:zh-tw": "新北市第二選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -3646,7 +3646,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "新北市第八選舉區"
+        "lang:zh-tw": "新北市第八選舉區"
       },
       "parent_id": "Q244898"
     },
@@ -3670,7 +3670,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "臺東縣選舉區"
+        "lang:zh-tw": "臺東縣選舉區"
       },
       "parent_id": "Q249904"
     },
@@ -3694,7 +3694,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "花蓮縣選舉區"
+        "lang:zh-tw": "花蓮縣選舉區"
       },
       "parent_id": "Q249868"
     },
@@ -3718,7 +3718,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "澎湖縣選舉區"
+        "lang:zh-tw": "澎湖縣選舉區"
       },
       "parent_id": "Q198525"
     },
@@ -3742,7 +3742,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "雲林縣第二選舉區"
+        "lang:zh-tw": "雲林縣第二選舉區"
       },
       "parent_id": "Q153221"
     },
@@ -3766,8 +3766,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Kaohsiung City",
-        "lang:zh_TW": "高雄市"
+        "lang:en": "Kaohsiung City",
+        "lang:zh-tw": "高雄市"
       },
       "parent_id": "Q865"
     },
@@ -3791,8 +3791,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -3816,7 +3816,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "南投縣第一選舉區"
+        "lang:zh-tw": "南投縣第一選舉區"
       },
       "parent_id": "Q82357"
     },
@@ -3840,7 +3840,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "連江縣選舉區"
+        "lang:zh-tw": "連江縣選舉區"
       },
       "parent_id": "Q249872"
     },
@@ -3864,7 +3864,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "金門縣選舉區"
+        "lang:zh-tw": "金門縣選舉區"
       },
       "parent_id": "Q249870"
     },
@@ -3888,7 +3888,7 @@
         "lang:en": "Taiwan legislative election regional district"
       },
       "name": {
-        "lang:zh_TW": "雲林縣第一選舉區"
+        "lang:zh-tw": "雲林縣第一選舉區"
       },
       "parent_id": "Q153221"
     },
@@ -3912,8 +3912,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Pingtung County",
-        "lang:zh_TW": "屏東縣"
+        "lang:en": "Pingtung County",
+        "lang:zh-tw": "屏東縣"
       },
       "parent_id": "Q865"
     },
@@ -3937,8 +3937,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Penghu County",
-        "lang:zh_TW": "澎湖縣"
+        "lang:en": "Penghu County",
+        "lang:zh-tw": "澎湖縣"
       },
       "parent_id": "Q865"
     },
@@ -3962,8 +3962,8 @@
         "lang:en": "constituency"
       },
       "name": {
-        "lang:en_US": "Lowland Aborigine district of national legislators electoral area",
-        "lang:zh_TW": "平地原住民立法委員選區"
+        "lang:en": "Lowland Aborigine district of national legislators electoral area",
+        "lang:zh-tw": "平地原住民立法委員選區"
       },
       "parent_id": null
     },
@@ -3987,8 +3987,8 @@
         "lang:en": "constituency"
       },
       "name": {
-        "lang:en_US": "Highland Aborigine district of national legislators electoral area",
-        "lang:zh_TW": "山地原住民立法委員選區"
+        "lang:en": "Highland Aborigine district of national legislators electoral area",
+        "lang:zh-tw": "山地原住民立法委員選區"
       },
       "parent_id": null
     },
@@ -4012,8 +4012,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Yilan County",
-        "lang:zh_TW": "宜蘭縣"
+        "lang:en": "Yilan County",
+        "lang:zh-tw": "宜蘭縣"
       },
       "parent_id": "Q865"
     },
@@ -4037,8 +4037,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "New Taipei City",
-        "lang:zh_TW": "新北市"
+        "lang:en": "New Taipei City",
+        "lang:zh-tw": "新北市"
       },
       "parent_id": "Q865"
     },
@@ -4062,8 +4062,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taichung City",
-        "lang:zh_TW": "臺中市"
+        "lang:en": "Taichung City",
+        "lang:zh-tw": "臺中市"
       },
       "parent_id": "Q865"
     },
@@ -4087,8 +4087,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hualien County",
-        "lang:zh_TW": "花蓮縣"
+        "lang:en": "Hualien County",
+        "lang:zh-tw": "花蓮縣"
       },
       "parent_id": "Q865"
     },
@@ -4112,8 +4112,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Kinmen County",
-        "lang:zh_TW": "金門縣"
+        "lang:en": "Kinmen County",
+        "lang:zh-tw": "金門縣"
       },
       "parent_id": "Q865"
     },
@@ -4137,8 +4137,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Lienchiang County",
-        "lang:zh_TW": "連江縣"
+        "lang:en": "Lienchiang County",
+        "lang:zh-tw": "連江縣"
       },
       "parent_id": "Q865"
     },
@@ -4162,8 +4162,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Taitung County",
-        "lang:zh_TW": "臺東縣"
+        "lang:en": "Taitung County",
+        "lang:zh-tw": "臺東縣"
       },
       "parent_id": "Q865"
     },
@@ -4187,8 +4187,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Hsinchu City",
-        "lang:zh_TW": "新竹市"
+        "lang:en": "Hsinchu City",
+        "lang:zh-tw": "新竹市"
       },
       "parent_id": "Q865"
     },
@@ -4212,8 +4212,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Chiayi City",
-        "lang:zh_TW": "嘉義市"
+        "lang:en": "Chiayi City",
+        "lang:zh-tw": "嘉義市"
       },
       "parent_id": "Q865"
     },
@@ -4237,8 +4237,8 @@
         "lang:en": "provincial city"
       },
       "name": {
-        "lang:en_US": "Keelung City",
-        "lang:zh_TW": "基隆市"
+        "lang:en": "Keelung City",
+        "lang:zh-tw": "基隆市"
       },
       "parent_id": "Q865"
     },
@@ -4262,8 +4262,8 @@
         "lang:en": "constituency"
       },
       "name": {
-        "lang:en_US": "Proportional Representation in national legislative election",
-        "lang:zh_TW": "全國不分區"
+        "lang:en": "Proportional Representation in national legislative election",
+        "lang:zh-tw": "全國不分區"
       },
       "parent_id": null
     },
@@ -4287,8 +4287,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Miaoli County",
-        "lang:zh_TW": "苗栗縣"
+        "lang:en": "Miaoli County",
+        "lang:zh-tw": "苗栗縣"
       },
       "parent_id": "Q865"
     },
@@ -4312,8 +4312,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Hsinchu County",
-        "lang:zh_TW": "新竹縣"
+        "lang:en": "Hsinchu County",
+        "lang:zh-tw": "新竹縣"
       },
       "parent_id": "Q865"
     },
@@ -4337,8 +4337,8 @@
         "lang:en": "county of Taiwan"
       },
       "name": {
-        "lang:en_US": "Nantou County",
-        "lang:zh_TW": "南投縣"
+        "lang:en": "Nantou County",
+        "lang:zh-tw": "南投縣"
       },
       "parent_id": "Q865"
     },
@@ -4362,8 +4362,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q7676191/Q49996581/popolo-m17n.json
+++ b/legislative/Q7676191/Q49996581/popolo-m17n.json
@@ -960,8 +960,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Tainan City",
-        "lang:zh_TW": "臺南市"
+        "lang:en": "Tainan City",
+        "lang:zh-tw": "臺南市"
       },
       "parent_id": "Q865"
     },
@@ -985,7 +985,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第01選區"
+        "lang:zh-tw": "臺南市第01選區"
       },
       "parent_id": "Q140631"
     },
@@ -1009,7 +1009,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第02選區"
+        "lang:zh-tw": "臺南市第02選區"
       },
       "parent_id": "Q140631"
     },
@@ -1033,7 +1033,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第03選區"
+        "lang:zh-tw": "臺南市第03選區"
       },
       "parent_id": "Q140631"
     },
@@ -1057,7 +1057,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第04選區"
+        "lang:zh-tw": "臺南市第04選區"
       },
       "parent_id": "Q140631"
     },
@@ -1081,7 +1081,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第05選區"
+        "lang:zh-tw": "臺南市第05選區"
       },
       "parent_id": "Q140631"
     },
@@ -1105,7 +1105,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第06選區"
+        "lang:zh-tw": "臺南市第06選區"
       },
       "parent_id": "Q140631"
     },
@@ -1129,7 +1129,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第07選區"
+        "lang:zh-tw": "臺南市第07選區"
       },
       "parent_id": "Q140631"
     },
@@ -1153,7 +1153,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第08選區"
+        "lang:zh-tw": "臺南市第08選區"
       },
       "parent_id": "Q140631"
     },
@@ -1177,7 +1177,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第09選區"
+        "lang:zh-tw": "臺南市第09選區"
       },
       "parent_id": "Q140631"
     },
@@ -1201,7 +1201,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第10選區"
+        "lang:zh-tw": "臺南市第10選區"
       },
       "parent_id": "Q140631"
     },
@@ -1225,7 +1225,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第11選區"
+        "lang:zh-tw": "臺南市第11選區"
       },
       "parent_id": "Q140631"
     },
@@ -1249,7 +1249,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第12選區"
+        "lang:zh-tw": "臺南市第12選區"
       },
       "parent_id": "Q140631"
     },
@@ -1273,7 +1273,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第13選區"
+        "lang:zh-tw": "臺南市第13選區"
       },
       "parent_id": "Q140631"
     },
@@ -1297,7 +1297,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第14選區"
+        "lang:zh-tw": "臺南市第14選區"
       },
       "parent_id": "Q140631"
     },
@@ -1321,7 +1321,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第15選區"
+        "lang:zh-tw": "臺南市第15選區"
       },
       "parent_id": "Q140631"
     },
@@ -1345,7 +1345,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第16選區"
+        "lang:zh-tw": "臺南市第16選區"
       },
       "parent_id": "Q140631"
     },
@@ -1369,7 +1369,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第17選區"
+        "lang:zh-tw": "臺南市第17選區"
       },
       "parent_id": "Q140631"
     },
@@ -1393,7 +1393,7 @@
         "lang:en": "Constituency of Regional Councilors of Tainan"
       },
       "name": {
-        "lang:zh_TW": "臺南市第18選區"
+        "lang:zh-tw": "臺南市第18選區"
       },
       "parent_id": "Q140631"
     },
@@ -1417,8 +1417,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }

--- a/legislative/Q7676278/Q49996573/popolo-m17n.json
+++ b/legislative/Q7676278/Q49996573/popolo-m17n.json
@@ -1077,8 +1077,8 @@
         "lang:en": "special municipality"
       },
       "name": {
-        "lang:en_US": "Taipei City",
-        "lang:zh_TW": "臺北市"
+        "lang:en": "Taipei City",
+        "lang:zh-tw": "臺北市"
       },
       "parent_id": "Q865"
     },
@@ -1102,7 +1102,7 @@
         "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
-        "lang:zh_TW": "臺北市第01選區"
+        "lang:zh-tw": "臺北市第01選區"
       },
       "parent_id": "Q1867"
     },
@@ -1126,7 +1126,7 @@
         "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
-        "lang:zh_TW": "臺北市第02選區"
+        "lang:zh-tw": "臺北市第02選區"
       },
       "parent_id": "Q1867"
     },
@@ -1150,7 +1150,7 @@
         "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
-        "lang:zh_TW": "臺北市第03選區"
+        "lang:zh-tw": "臺北市第03選區"
       },
       "parent_id": "Q1867"
     },
@@ -1174,7 +1174,7 @@
         "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
-        "lang:zh_TW": "臺北市第04選區"
+        "lang:zh-tw": "臺北市第04選區"
       },
       "parent_id": "Q1867"
     },
@@ -1198,7 +1198,7 @@
         "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
-        "lang:zh_TW": "臺北市第05選區"
+        "lang:zh-tw": "臺北市第05選區"
       },
       "parent_id": "Q1867"
     },
@@ -1222,7 +1222,7 @@
         "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
-        "lang:zh_TW": "臺北市第06選區"
+        "lang:zh-tw": "臺北市第06選區"
       },
       "parent_id": "Q1867"
     },
@@ -1246,7 +1246,7 @@
         "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
-        "lang:zh_TW": "臺北市第07選區"
+        "lang:zh-tw": "臺北市第07選區"
       },
       "parent_id": "Q1867"
     },
@@ -1270,7 +1270,7 @@
         "lang:en": "Constituency of Regional Councilors of Taipei"
       },
       "name": {
-        "lang:zh_TW": "臺北市第08選區"
+        "lang:zh-tw": "臺北市第08選區"
       },
       "parent_id": "Q1867"
     },
@@ -1294,8 +1294,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Taiwan",
-        "lang:zh_TW": "中華民國"
+        "lang:en": "Taiwan",
+        "lang:zh-tw": "中華民國"
       },
       "parent_id": null
     }


### PR DESCRIPTION
I forgot to update boundaries/index.json with the new language codes when moving to Wikidata codes in 154543a, so this fixes that. Confirmed that none of the old codes are now present in the repo.